### PR TITLE
Build ADI LDR format executable for U-Boot Proper

### DIFF
--- a/arch/arm/mach-sc5xx/config.mk
+++ b/arch/arm/mach-sc5xx/config.mk
@@ -12,5 +12,7 @@ ifdef CONFIG_XPL_BUILD
 INPUTS-y += $(obj)/u-boot-spl.ldr
 endif
 
+INPUTS-y += u-boot.ldr
+
 LDR_FLAGS += --bcode=$(CONFIG_SC_BOOT_MODE)
 LDR_FLAGS += --use-vmas


### PR DESCRIPTION
I believe this is missing in upstream since the focus was on Falcon mode, but the default should be to support U-Boot proper as with all other boards and then disable `u-boot.ldr` when Falcon mode is enabled.