### PR TITLE
Add ADP5587 to ADP5588 driver compatible strings

### DIFF
--- a/drivers/gpio/adp5588_gpio.c
+++ b/drivers/gpio/adp5588_gpio.c
@@ -168,7 +168,7 @@ static int adp5588_ofdata_platdata(struct udevice *dev)
 
 	revid = ret & ID_MASK;
 
-	printf("ADP5588 Detected: Rev %x, Rev ID %x\n", ret, revid);
+	printf("ADP558x Detected: Rev %x, Rev ID %x\n", ret, revid);
 
 	for (i = 0, ret = 0; i <= ADP5588_BANK(ADP5588_MAXGPIO); i++) {
 		plat->dat_out[i] = adp5588_gpio_read(dev, GPIO_DAT_OUT1 + i);
@@ -194,6 +194,7 @@ static const struct dm_gpio_ops adp5588_ops = {
 
 static const struct udevice_id adp5588_of_match_list[] = {
 	{ .compatible = "adi,adp5588"},
+	{ .compatible = "adi,adp5587"},
 	{ /* sentinel */ }
 };
 


### PR DESCRIPTION
Our downstream devicetree specified ADP5588 in the devicetree, when it is in fact a ADP5587. This is needed for EV-SC598-SOM Rev E support, but generic enough that we can submit it separately.