### PR TITLE
Setup initial CI/CD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-Please do not submit a Pull Request via github.  Our project makes use of
-mailing lists for patch submission and review.  For more details please
-see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html
-
-The only exception to this is in order to trigger a CI loop on Azure prior
-to posting of patches.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: U-Boot CI
+
+on:
+  pull_request:
+    branches:
+      - 'adi-u-boot-2025.07.y'
+
+jobs:
+  build_arm:
+    uses: analogdevicesinc/u-boot/.github/workflows/build-arm.yml@ci
+    with:
+      defconfig: ${{ matrix.defconfig }}
+    strategy:
+      matrix:
+        defconfig:
+          - 'sc594-som-ezkit-spl_defconfig'
+
+  build_aarch64:
+    uses: analogdevicesinc/u-boot/.github/workflows/build-aarch64.yml@ci
+    with:
+      defconfig: ${{ matrix.defconfig }}
+    strategy:
+      matrix:
+        defconfig:
+          - 'sc598-som-ezkit-spl_defconfig'


### PR DESCRIPTION
Disable the PR template from mainline U-Boot and add a basic workflow. To limit the amount of changes required on our development branches, as much logic as possible is stored in workflows on a `ci` branch in this repo.