### PR TITLE
mach-sc5xx: generate U-Boot proper in ADI ldr format

### DIFF
--- a/arch/arm/mach-sc5xx/config.mk
+++ b/arch/arm/mach-sc5xx/config.mk
@@ -12,5 +12,7 @@ ifdef CONFIG_XPL_BUILD
 INPUTS-y += $(obj)/u-boot-spl.ldr
 endif
 
+INPUTS-y += u-boot.ldr
+
 LDR_FLAGS += --bcode=$(CONFIG_SC_BCODE)
 LDR_FLAGS += --use-vmas


### PR DESCRIPTION
Generating an ldr boot stream containing U-Boot Proper was never added to U-Boot because it is done by the ADI Yocto layer. Add it to U-Boot to support projects that do not use that layer.


(cherry picked from commit 55014ce40e29fc4a8d5ec146b02ea0c660b03087)