### PR TITLE
Device tree cleanups and .env formatting for SC5xx boards

### DIFF
--- a/arch/arm/dts/sc573-ezkit.dts
+++ b/arch/arm/dts/sc573-ezkit.dts
@@ -14,7 +14,7 @@
 };
 
 &i2c0 {
-	gpio_expander1: mcp23017@21 {
+	crr_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -41,7 +41,7 @@
 			gpio-hog;
 			gpios = <5 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~mlb-en";
+			line-name = "mlb-en";
 			bootph-pre-ram;
 		};
 

--- a/arch/arm/dts/sc584-ezkit.dts
+++ b/arch/arm/dts/sc584-ezkit.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander1: mcp23017@21 {
+	crr_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -48,7 +48,7 @@
 			gpio-hog;
 			gpios = <5 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~mlb-en";
+			line-name = "mlb-en";
 			bootph-pre-ram;
 		};
 

--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -17,7 +17,7 @@
 &i2c0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	gpio_expander1: mcp23017@21 {
+	crr_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -68,7 +68,7 @@
 			gpio-hog;
 			gpios = <5 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~mlb-en";
+			line-name = "mlb-en";
 			bootph-pre-ram;
 		};
 

--- a/arch/arm/dts/sc594-som-ezkit.dts
+++ b/arch/arm/dts/sc594-som-ezkit.dts
@@ -104,7 +104,7 @@
 			gpio-hog;
 			gpios = <12 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~mlb-en";
+			line-name = "mlb-en";
 			bootph-pre-ram;
 		};
 

--- a/arch/arm/dts/sc594-som.dtsi
+++ b/arch/arm/dts/sc594-som.dtsi
@@ -80,7 +80,7 @@
 &i2c2 {
 	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
 
-	gpio_expander1: mcp23017@21 {
+	crr_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;

--- a/arch/arm/dts/sc598-som-ezkit.dts
+++ b/arch/arm/dts/sc598-som-ezkit.dts
@@ -112,7 +112,7 @@
 			gpio-hog;
 			gpios = <12 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~mlb-en";
+			line-name = "mlb-en";
 			bootph-pre-ram;
 		};
 

--- a/arch/arm/dts/sc598-som-revE.dtsi
+++ b/arch/arm/dts/sc598-som-revE.dtsi
@@ -8,7 +8,7 @@
 #include "sc598-som.dtsi"
 
 &i2c2 {
-	gpio_expander1: adp5587@34 {
+	som_gpio_expander: adp5587@34 {
 		compatible = "adi,adp5587";
 		reg = <0x34>;
 		gpio-controller;

--- a/board/adi/sc573-ezkit/sc573-ezkit.env
+++ b/board/adi/sc573-ezkit/sc573-ezkit.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc584-ezkit/sc584-ezkit.env
+++ b/board/adi/sc584-ezkit/sc584-ezkit.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc589-ezkit/sc589-ezkit.env
+++ b/board/adi/sc589-ezkit/sc589-ezkit.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc589-mini/sc589-mini.env
+++ b/board/adi/sc589-mini/sc589-mini.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc594-som-ezkit/sc594-som-ezkit.env
+++ b/board/adi/sc594-som-ezkit/sc594-som-ezkit.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc594-som-ezlite/sc594-som-ezlite.env
+++ b/board/adi/sc594-som-ezlite/sc594-som-ezlite.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc598-som-ezkit/sc598-som-ezkit.env
+++ b/board/adi/sc598-som-ezkit/sc598-som-ezkit.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */

--- a/board/adi/sc598-som-ezlite/sc598-som-ezlite.env
+++ b/board/adi/sc598-som-ezlite/sc598-som-ezlite.env
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later+ */
-
 /*
  * (C) Copyright 2024 - Analog Devices, Inc.
  */


### PR DESCRIPTION
Fixes the issues mentioned in https://github.com/analogdevicesinc/u-boot/pull/30. 