### PR TITLE
board: adi: Fix missing semicolon in nfsroot

### DIFF
--- a/include/env/adi/adi_boot.env
+++ b/include/env/adi/adi_boot.env
@@ -41,7 +41,7 @@ addip=setenv bootargs ${bootargs} ip=${ipaddr}:${serverip}:${gatewayip}:${netmas
 /* Boot modes are selectable and should be defined in the board env before including */
 #if defined(USE_NFS)
 // rootpath is set by CONFIG_ROOTPATH
-nfsargs=setenv bootargs root=/dev/nfs rw nfsroot=${serverip}${rootpath},tcp,nfsvers=3 ${adi_bootargs}
+nfsargs=setenv bootargs root=/dev/nfs rw nfsroot=${serverip}:${rootpath},tcp,nfsvers=3 ${adi_bootargs}
 nfsboot=run init_ethernet;
 	tftp ${loadaddr} ${tftp_dir_prefix}${imagefile};
 	run nfsargs;


### PR DESCRIPTION
The nfsroot constructed as part of the default Analog Devices boot strategy is missing a semicolon between the server ip and the root path itself. This adds the missing semicolon.

(cherry picked from commit 70ab39e2305f6ab9b7b1752e26b0e4293129009b)

Fixes #36 