### PR TITLE
adi: Stop disabling device tree relocation

### DIFF
--- a/include/env/adi/adi_boot.env
+++ b/include/env/adi/adi_boot.env
@@ -20,10 +20,8 @@ ethaddr=02:80:ad:20:31:e8
 eth1addr=02:80:ad:20:31:e9
 uart_console=CONFIG_UART_CONSOLE
 #ifdef CONFIG_SC59X_64
-fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 #else
-fdt_high=0xffffffff
 initrd_high=0xffffffff
 #endif
 


### PR DESCRIPTION
Remove setting of fdt_high to ~0, which disables device tree relocation, from the default environment. Doing so prevents U-Boot from correcting problems such as having an unaligned device tree and leads to various failure modes in the OS.

Tested-by: Greg Malysa <malysagreg@gmail.com>

(cherry picked from commit bcc53242b95f0d2e4b51e7e3e6b26c0b34790eb6)

Fixes #39 