### PR TITLE
arm: dts: rename GPIO expanders

### DIFF
--- a/arch/arm/dts/sc573-ezkit.dts
+++ b/arch/arm/dts/sc573-ezkit.dts
@@ -14,7 +14,7 @@
 };
 
 &i2c0 {
-	gpio_expander1: mcp23017@21 {
+	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -118,7 +118,7 @@
 		};
 	};
 
-	gpio_expander2: mcp23017@22 {
+	gpio_expander1: mcp23017@22 {
 		compatible = "microchip,mcp23017";
 		reg = <0x22>;
 		gpio-controller;

--- a/arch/arm/dts/sc584-ezkit.dts
+++ b/arch/arm/dts/sc584-ezkit.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander1: mcp23017@21 {
+	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -125,7 +125,7 @@
 		};
 	};
 
-	gpio_expander2: mcp23017@22 {
+	gpio_expander1: mcp23017@22 {
 		compatible = "microchip,mcp23017";
 		reg = <0x22>;
 		gpio-controller;

--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -17,7 +17,7 @@
 &i2c0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	gpio_expander1: mcp23017@21 {
+	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;
@@ -145,7 +145,7 @@
 		};
 	};
 
-	gpio_expander2: mcp23017@22 {
+	gpio_expander1: mcp23017@22 {
 		compatible = "microchip,mcp23017";
 		reg = <0x22>;
 		gpio-controller;

--- a/arch/arm/dts/sc594-som-ezkit.dts
+++ b/arch/arm/dts/sc594-som-ezkit.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander2: mcp23017@22 {
+	crr_gpio_expander: mcp23017@22 {
 		compatible = "microchip,mcp23017";
 		reg = <0x22>;
 		gpio-controller;

--- a/arch/arm/dts/sc594-som-ezlite.dts
+++ b/arch/arm/dts/sc594-som-ezlite.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander: adp5588@30 {
+	crr_gpio_expander: adp5588@30 {
 		compatible = "adi,adp5588";
 		reg = <0x30>;
 		gpio-controller;

--- a/arch/arm/dts/sc594-som.dtsi
+++ b/arch/arm/dts/sc594-som.dtsi
@@ -80,7 +80,7 @@
 &i2c2 {
 	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
 
-	gpio_expander1: mcp23017@21 {
+	som_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;
 		gpio-controller;

--- a/arch/arm/dts/sc598-som-ezkit.dts
+++ b/arch/arm/dts/sc598-som-ezkit.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander2: mcp23017@22 {
+	crr_gpio_expander: mcp23017@22 {
 		compatible = "microchip,mcp23017";
 		reg = <0x22>;
 		gpio-controller;

--- a/arch/arm/dts/sc598-som-ezlite.dts
+++ b/arch/arm/dts/sc598-som-ezlite.dts
@@ -13,7 +13,7 @@
 };
 
 &i2c2 {
-	gpio_expander: adp5588@30 {
+	crr_gpio_expander: adp5588@30 {
 		compatible = "adi,adp5588";
 		reg = <0x30>;
 		gpio-controller;

--- a/arch/arm/dts/sc598-som-revE.dtsi
+++ b/arch/arm/dts/sc598-som-revE.dtsi
@@ -8,7 +8,7 @@
 #include "sc598-som.dtsi"
 
 &i2c2 {
-	gpio_expander1: adp5587@34 {
+	som_gpio_expander: adp5587@34 {
 		compatible = "adi,adp5587";
 		reg = <0x34>;
 		gpio-controller;


### PR DESCRIPTION
Patch for ADSP SC5xxx boards to have proper GPIO expander names.
Please note that this commit is not directly compatible with adi-u-boot-2025.07.y