### PR TITLE
checks.yml: add u-boot-specific scripts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,24 +2,29 @@ name: Checks
 
 on:
   workflow_call:
+    inputs:
+      strategy:
+        required: false
+        type: string
+        default: "commit" # when supported, or "file"
+      checkpatch_extraignores:
+        type: string
+        default: ""
     outputs:
       fatal:
         value: ${{ jobs.checks.outputs.fatal}}
-      fail:
-        value: ${{ jobs.checks.outputs.fail }}
-      warn:
-        value: ${{ jobs.checks.outputs.warn }}
+      summary:
+        value: ${{ jobs.checks.outputs.summary }}
 
 jobs:
   checks:
     timeout-minutes: 7200
-    runs-on: [self-hosted, repo-only, v3]
+    runs-on: [self-hosted, repo-only, v4]
     continue-on-error: true
 
     outputs:
       fatal: ${{ steps.assert.outputs.fatal }}
-      fail: ${{ steps.assert.outputs.fail }}
-      warn: ${{ steps.assert.outputs.warn }}
+      summary: ${{ steps.assert.outputs.summary }}
 
     steps:
     - uses: analogdevicesinc/doctools/checkout@action
@@ -27,9 +32,9 @@ jobs:
     - name: Get sources
       run: |
         get_file () {
-          echo https://raw.githubusercontent.com/analogdevicesinc/linux/refs/heads/ci/$1
+          echo https://raw.githubusercontent.com/analogdevicesinc/u-boot/refs/heads/ci/$1
           curl -sL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -o $1 \
-              https://raw.githubusercontent.com/analogdevicesinc/linux/refs/heads/ci/$1
+              https://raw.githubusercontent.com/analogdevicesinc/u-boot/refs/heads/ci/$1
         }
 
         mkdir -p ci
@@ -57,7 +62,8 @@ jobs:
     - name: Check patch
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        status=0; timeout 1d bash -c "source ./ci/build.sh ; check_checkpatch" || status=$?
+        export CHECKPATCH_EXTRAIGNORES="${{ inputs.checkpatch_extraignores }}";
+        status=0; timeout 1d bash -c "source ./ci/build.sh ; check_checkpatch ${{ inputs.strategy }}" || status=$?
         [ $status -eq 124 ] && echo "step_fail_checkpatch_timeout=true" >> "$GITHUB_ENV"
         exit $status
 
@@ -67,12 +73,6 @@ jobs:
         status=0; timeout 1d bash -c "source ./ci/build.sh ; check_coccicheck" || status=$?
         [ $status -eq 124 ] && echo "step_fail_coccicheck_timeout=true" >> "$GITHUB_ENV"
         exit $status
-
-    - name: Check dt-bindings
-      if: ${{ !cancelled() && env.fatal != 'true' }}
-      run: |
-        source ./ci/build.sh
-        check_dt_binding_check
 
     - name: Check defconfigs
       if: ${{ !cancelled() && env.fatal != 'true' }}
@@ -90,4 +90,4 @@ jobs:
       run: |
         echo "fatal=$fatal" >> "$GITHUB_OUTPUT"
         source ./ci/runner_env.sh
-        export_labels
+        export_job_summary

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,375 @@
+if [[ -z "$run_id" ]]; then
+	export run_id=$(uuidgen)
+fi
+
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+	export _n='%0A'
+	export _c='%2C'
+else
+	export _n=$'\n'
+	export _c=$','
+	export _color='--color'
+fi
+
+[[ ! -v CI_WORKTREE ]] && export CI_WORKTREE='.'
+
+_fmt() {
+	msg=$(echo "$1" | tr -d '\t')
+	if [[ ! "$_n" == $'\n' ]]; then
+		msg=$(printf "$msg" | sed ':a;N;$!ba;s/\n/'"$_n"'/g')
+	fi
+	printf "%s\n" "$msg"
+}
+
+_file () {
+	echo "$1" | sed 's/,/'"$_c"'/g'
+}
+
+check_checkpatch() {
+	export step_name="checkpatch"
+	local strategy=${1:-commit} # or per file
+	local mail=
+	local fail=0
+	local warn=0
+	local ignored=
+	local tmp_branch_name=$(git symbolic-ref --short HEAD)-$RANDOM
+	local checkpatch_opts
+
+	checkpatch_opts="--strict \
+			--ignore FILE_PATH_CHANGES \
+			--ignore LONG_LINE \
+			--ignore LONG_LINE_STRING \
+			--ignore LONG_LINE_COMMENT \
+			--ignore PARENTHESIS_ALIGNMENT \
+			--ignore CAMELCASE \
+			--ignore UNDOCUMENTED_DT_STRING \
+			--ignore UNKNOWN_COMMIT_ID \
+		"
+
+	echo "$step_name on range $base_sha..$head_sha"
+
+	for ignore in $CHECKPATCH_EXTRAIGNORES; do
+		checkpatch_opts="$checkpatch_opts --ignore $ignore"
+	done
+
+	if [[ "$strategy" == "file" ]]; then
+		# To still only check the changes, squash the range in a single commit
+		git switch -c $tmp_branch_name 1>/dev/null
+		git reset --soft $base_sha
+		git commit -m "[TEMP] check: Squashed range" -m "Signed-off-by: CSE CI <cse-ci-notifications@analog.com>"
+
+		checkpatch_opts="$checkpatch_opts \
+			--ignore COMMIT_MESSAGE \
+			--ignore DT_SPLIT_BINDING_PATCH"
+
+		[[ "$GITHUB_ACTIONS" != "true" ]] && echo "Attention! At temp branch '$tmp_branch_name'. If you cancel (Ctrl+C), also revert with 'git switch -'"
+	fi
+	[[ "$strategy" == "commit" ]] && commits=$(git rev-list $base_sha..$head_sha --reverse) || commits=$(git rev-parse @)
+
+	python3 -m venv ~/venv
+	source ~/venv/bin/activate
+	python3 -m ensurepip --upgrade
+	pip3 install ply GitPython --upgrade
+
+	# The output is not properly captured with --git
+	for commit in $commits; do
+		git --no-pager log --oneline $commit~..$commit
+		# Skip empty commits, assume cover letter
+		# and those only touching non-upstream directories .github ci and docs
+		# A treeless (--filter=tree:0) fetch could be done to fetch
+		# full commit message history before running checkpatch, but
+		# that may mess-up the cache and is only useful for checking
+		# SHA references in the commit message, with may not even apply
+		# if the commit is from upstream. Instead, just delegate to the
+		# user to double check the referenced SHA.
+		local files=$(git diff --diff-filter=ACM --no-renames --name-only "$commit~..$commit" | grep -v ^ci | grep -v ^.github | grep -v ^docs || true)
+		if [[ -z "$files" ]]; then
+			echo "empty, skipped"
+			continue
+		else
+			echo $files
+		fi
+
+		_echo_ci "scripts/checkpatch.pl --git $commit $checkpatch_opts"
+		mail=$(scripts/checkpatch.pl \
+			--git "$commit" \
+			$checkpatch_opts )
+
+		ignored=0
+		found=0
+		msg=
+
+		while read -r row
+		do
+			if [[ "$row" =~ ^total: ]]; then
+				echo -e "\e[1m$row\e[0m"
+				break
+			fi
+
+			# Additional parsing is needed
+			if [[ "$found" == "1" ]]; then
+
+				# The row is started with "#"
+				if [[ "$row" =~ ^\# ]]; then
+					# Split the string using ':' separator
+					IFS=':' read -r -a list <<< "$row"
+
+					# Get file-name after removing spaces.
+					file=$(echo ${list[2]} | xargs)
+
+					# Get line-number
+					line=${list[3]}
+					_echo_ci $row
+				else
+					msg=${msg}${row}$_n
+					if [[ -z $row ]]; then
+						if [[ -z $file ]]; then
+							# If no file, add to file 0 of first file on list.
+							file=$(git show --name-only --pretty=format: $commit | head -n 1)
+							echo "::$type file=$(_file "$file"),line=0::$step_name: $msg"
+						else
+							[[ "$type" == "error" ]] && fail=1
+							[[ "$type" == "warning" ]] && warn=1
+							echo "::$type file=$(_file "$file"),line=$line::$step_name: $msg"
+						fi
+						found=0
+						file=
+						line=
+						type=
+					fi
+				fi
+			fi
+
+			if [[ "$row" =~ ^ERROR: ]]; then
+				type="error"
+			elif [[ "$row" =~ ^WARNING: ]]; then
+				type="warning"
+			elif [[ "$row" =~ ^CHECK: ]]; then
+				type="warning"
+			fi
+			if [[ "$row" =~ ^(CHECK|WARNING|ERROR): ]]; then
+				msg=$(echo "$row" | sed -E  's/^(CHECK|WARNING|ERROR): //')$_n
+				found=1
+				file=
+				line=
+			else
+				if [[ "$found" == "0" ]]; then
+					echo $row
+				fi
+			fi
+
+		done <<< "$mail"
+		echo "       of those, $ignored were ignored"
+	done
+
+	[[ "$strategy" == "file" ]] && (git switch - 1>/dev/null; git branch -D $tmp_branch_name)
+
+	_set_step_warn $warn
+	return $fail
+}
+
+check_coccicheck() {
+	export step_name="coccicheck"
+	local files=$(git diff --diff-filter=ACM --no-renames --name-only $base_sha..$head_sha -- '**/*.c')
+	local mail=
+	local warn=0
+
+	echo "$step_name on range $base_sha..$head_sha"
+
+	[[ -z "$ARCH" ]] && ARCH=x86
+
+	coccis=$(ls scripts/coccinelle/**/*.cocci)
+	[[ -z "$coccis" ]] && return 0
+	[[ -z "$files" ]] && return 0
+	while read file; do
+		echo -e "\e[1m$file\e[0m"
+
+		while read cocci; do
+
+			mail=$(spatch -D report  --very-quiet --cocci-file $cocci --no-includes \
+				    --include-headers --patch . \
+				    -I arch/$ARCH/include -I arch/$ARCH/include/generated -I include \
+				    -I arch/$ARCH/include/uapi -I arch/$ARCH/include/generated/uapi \
+				    -I include/uapi -I include/generated/uapi \
+				    --include include/linux/compiler-version.h \
+				    --include include/linux/kconfig.h $file || true)
+
+			msg=
+
+			while read -r row
+			do
+				# There is no standard for cocci, so this is the best we can do
+				# is match common beginnings and log the rest
+				if [[ "$row" =~ ^$file: ]]; then
+					type="warning"
+					warn=1
+				fi
+
+				if [[ "$row" =~ ^(warning): ]]; then
+					# warning: line 223: should nonseekable_open be a metavariable?
+					# internal cocci warning, not user fault
+					echo $row
+				elif [[ "$row" =~ ^$file: ]]; then
+					# drivers/iio/.../adi_adrv9001_fh.c:645:67-70: duplicated argument to & or |
+					IFS=':' read -r -a list <<< "$row"
+					line=${list[1]}
+					msg=
+					for ((i=2; i<${#list[@]}; i++)); do
+						msg="$msg${list[$i]} "
+					done
+					echo "::$type file=$(_file "$file"),line=$line::$step_name: $msg"
+				else
+					if [[ "$row" ]]; then
+						echo $row
+					fi
+				fi
+
+			done <<< "$mail"
+
+		done <<< "$coccis"
+
+	done <<< "$files"
+
+	_set_step_warn $warn
+	return 0
+}
+
+_bad_licence_error() {
+	local license_error="
+	File is being added to Analog Devices U-Boot tree.
+	Analog Devices code is being marked dual-licensed... Make sure this is really intended!
+	If not intended, change MODULE_LICENSE() or the SPDX-License-Identifier accordingly.
+	This is not as simple as one thinks and upstream might require a lawyer to sign the patches!"
+	_fmt "::warning file=$1::$step_name: $license_error"
+}
+
+check_license() {
+	export step_name="check_license"
+	local fail=0
+
+	echo "$step_name on range $base_sha..$head_sha"
+
+	local added_files=$(git diff --diff-filter=A --name-only "$base_sha..$head_sha")
+
+	# Get list of new files in the commit range
+	for file in $added_files ; do
+		if git diff $base_sha..$head_sha "$file" 2>/dev/null | grep "^+MODULE_LICENSE" | grep -q "Dual" ; then
+			_bad_licence_error "$file"
+			fail=1
+		elif git diff $base_sha..$head_sha "$file" 2>/dev/null | grep "^+// SPDX-License-Identifier:" | grep -qi " OR " ; then
+			# The below might catch bad licenses in header files and also helps to make sure dual licenses are
+			# not in driver (e.g.: sometimes people have MODULE_LICENSE != SPDX-License-Identifier - which is also
+			# wrong and maybe something to improve in this job).
+			# For devicetree-related files, allow dual license if GPL-2.0 is one of them.
+			if [[ "$file" == *.@(yaml|dts|dtsi|dtso) ]]; then
+				if cat "$file" | grep "^// SPDX-License-Identifier:" | grep -q "GPL-2.0" ; then
+					continue
+				fi
+			fi
+			_bad_licence_error "$file"
+			fail=1
+		fi
+	done
+
+	_set_step_warn $warn
+	return $fail
+}
+
+check_assert_defconfigs() {
+	export step_name="check_assert_defconfigs"
+	local fail=0
+	local arch
+	local defconfig
+	local file
+	local message="
+	Verify if the changes are coherent, for example, the changes were not
+	caused by a mistakenly set Kconfig, and if so, run 'make savedefconfig',
+	overwrite the defconfig and commit it.
+	"
+
+	echo "$step_name"
+	for arg in "$@"; do
+		arch=$(cut -d "/" -f1 <<< "$arg")
+		[[ "$arch" == "arm64" ]] && arch_=aarch64 || arch_=$arch
+		defconfig=$(cut -d "/" -f2 <<< "$arg")
+		file=arch/$arch/configs/$defconfig
+
+		if [[ -f $file ]]; then
+			echo $file
+			set_arch gcc_$arch_ 1>/dev/null
+			make $defconfig savedefconfig 1>/dev/null
+			rm .config
+
+			mv defconfig $file
+			out=$(git diff $_color --exit-code $file) || {
+				_fmt "::error file=$file::$step_name: Defconfig '$file' changed. $message
+				      $out"
+				fail=1
+			}
+			git restore $file
+		fi
+	done
+
+	return $fail
+}
+
+apply_prerun() {
+	export step_name="apply_prerun"
+	# Run cocci and bash scripts from ci/prerun
+	# e.g. manipulate the source code depending on run conditons or target.
+	local coccis=$(ls ci/prerun/*.cocci 2>/dev/null)
+	local bashes=$(ls ci/prerun/*.sh 2>/dev/null)
+	local files=$(git diff --diff-filter=ACM --no-renames --name-only $base_sha..$head_sha -- '**/*.c')
+
+	echo "$step_name on range $base_sha..$head_sha"
+	[[ -z "$files" ]] && return 0
+	if [[ ! -z "$coccis" ]]; then
+		while read cocci; do
+			echo "apply $cocci"
+			while read file; do
+				echo -e "\e[1m$cocci $file\e[0m"
+				spatch --sp-file $cocci --in-place $file
+			done <<< "$files"
+		done <<< "$coccis"
+	fi
+
+	if [[ ! -z "$bashes" ]]; then
+		while read bashs; do
+			echo "apply $bashs"
+			while read file; do
+				echo -e "\e[1m$bashs $file\e[0m"
+				$bashs $file
+			done <<< "$files"
+		done <<< "$bashes"
+	fi
+}
+
+set_step_warn () {
+	[[ -z "$GITHUB_ENV" ]] && return
+	echo ; echo "step_warn_$1=true" >> "$GITHUB_ENV"
+}
+
+set_step_fail () {
+	[[ -z "$GITHUB_ENV" ]] && return
+	echo ; echo "step_fail_$1=true" >> "$GITHUB_ENV"
+}
+
+_set_step_warn () {
+	if [[ "$1" == "1" ]] || [[ "$1" == "true" ]] ; then
+		set_step_warn "$step_name"
+	fi
+}
+
+_set_step_fail () {
+	if [[ ! -z "$step_name" ]]; then
+		set_step_fail "$step_name"
+		unset step_name
+	fi
+}
+
+_echo_ci () {
+	[[ "$GITHUB_ACTIONS" != "true" ]] && return
+	echo "$@"
+}
+
+trap '_set_step_fail' ERR

--- a/ci/runner_env.sh
+++ b/ci/runner_env.sh
@@ -1,0 +1,95 @@
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+	export _n='%0A'
+else
+	export _n=$'\n'
+fi
+
+_fmt() {
+	msg=$(echo "$1" | tr -d '\t')
+	if [[ ! "$_n" == $'\n' ]]; then
+		msg=$(printf "$msg" | sed ':a;N;$!ba;s/\n/'"$_n"'/g')
+	fi
+	printf "%s\n" "$msg"
+}
+
+export_job_summary () {
+	json=$(printenv | jq -R -n '
+		[inputs] | map(select(index("="))) | map(split("=") | {(.[0]): .[1]}) | add
+		| to_entries
+		| group_by(
+				if .key | startswith("step_fail_") then
+					"fail"
+				elif .key | startswith("step_warn_") then
+					"warn"
+				else
+					"other"
+				end
+			)
+		| map(
+				if .[0].key | startswith("step_fail_") then
+					{"fail": map({ (.key|sub("^step_fail_";"")): .value }) | add }
+				elif .[0].key | startswith("step_warn_") then
+					{"warn": map({ (.key|sub("^step_warn_";"")): .value }) | add }
+				else
+					empty
+				end
+			)
+		| add
+	')
+	if [[ "$json" == "null" ]]; then json="" ; fi
+
+	echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+	echo "$json" >> $GITHUB_OUTPUT
+	echo "EOF" >> "$GITHUB_OUTPUT"
+}
+
+assert_job_summary () {
+	local msg="
+	Errors and warnings are annotated on the changed files, in each job step, as well as aggregated on the Summary page.
+	Some messages may not cause the step to fail, but still need to be checked."
+	local fail=""
+	local warn=""
+
+	for _job_var_name in $(compgen -A variable job_); do
+		local job_name="${_job_var_name#job_}"
+		local json="${!_job_var_name}"
+		echo "$job_name"
+
+		local fail_=$(
+			echo "$json" | jq -r '
+				.fail | to_entries |
+				map(
+					"    step \(.key)"
+				) |
+				.[]
+			' 2>/dev/null
+		)
+		[[ -n "$fail_" ]] && fail+=$'\n'"  job $job_name:"$'\n'"$fail_"
+
+		local warn_=$(
+			echo "$json" | jq -r '
+				.warn | to_entries |
+				map(
+					"    step \(.key)"
+				) |
+				.[]
+			' 2>/dev/null
+		)
+		[[ -n "$warn_" ]] && warn+=$'\n'"  job $job_name:"$'\n'"$warn_"
+	done
+
+	if [[ -n "$fail" ]]; then
+		if [[ -n "$warn" ]]; then
+			msg="::error::Some jobs didn't pass strict checks:$fail"$'\n'$'\n'"And non-strict checks:$warn"$'\n'$'\n'"$msg"
+		else
+			msg="::error::Some jobs didn't pass strict checks:$fail"$'\n'$'\n'"$msg"
+		fi
+		_fmt "$msg"
+		exit 1
+	else
+		if [[ -n "$warn" ]]; then
+			msg="::warning::Some jobs didn't pass non-strict checks:$warn"$'\n'$'\n'"$msg"
+		fi
+		_fmt "$msg"
+	fi
+}


### PR DESCRIPTION
I've taken the latest "ci/build.sh" from analogdevicesinc/linux@ci, and:

* removed the build logic, leaving only the "checks"
* modified the "checks" to be specific to u-boot (remove linux-specific workarounds)

I've removed the dt_bindings_check for now because u-boot doesn't have any bindings. It is possible to run u-boot device trees against linux kernel bindings in some cases, but this is not implemented.

The cocci functionality is untested.

The defconfig checks currently do nothing because there is no top-level.yml for this repo.

The checkpatch step takes an input: `checkpatch_extraignores`, a space-delimited list of checkpatch flags to ignore (on top of the basic ones).