### PR TITLE
arm: dts: sc594: Update sc594 EZKIT GPIO polarities

### DIFF
--- a/arch/arm/dts/sc594-som-ezkit.dts
+++ b/arch/arm/dts/sc594-som-ezkit.dts
@@ -22,7 +22,7 @@
 
 		eeprom {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
+			gpios = <0 GPIO_ACTIVE_LOW>;
 			output-low;
 			line-name = "eeprom-en";
 			bootph-pre-ram;
@@ -30,7 +30,7 @@
 
 		pushbutton {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
+			gpios = <1 GPIO_ACTIVE_LOW>;
 			output-low;
 			line-name = "pushbutton-en";
 			bootph-pre-ram;
@@ -70,7 +70,7 @@
 
 		octal {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
+			gpios = <8 GPIO_ACTIVE_LOW>;
 			output-low;
 			line-name = "octal-spi-cs-en";
 			bootph-pre-ram;


### PR DESCRIPTION
These changes were originally a patch in the ADSP meta layer. Moving them into the actual repo to mirror the changes already committed to the sc598 device tree.