### PR TITLE
arm/mach-sc5xx: don't select non-existent GIC_600_CLEAR_RDPD

### DIFF
--- a/arch/arm/mach-sc5xx/Kconfig
+++ b/arch/arm/mach-sc5xx/Kconfig
@@ -41,7 +41,6 @@ config SC59X_64
 	select COMMON_CLK_ADI_SC598
 	select GICV3
 	select GICV3_SUPPORT_GIC600
-	select GIC_600_CLEAR_RDPD
 	select MMC_SDHCI_ADMA_FORCE_32BIT
 	select NOP_PHY if PHY
 


### PR DESCRIPTION
The symbol CONFIG_GIC_600_CLEAR_RDPD does not exist. Don't select it.


Fixes: 48a0b0b4b7d7 ("arch: arm: Add Analog Devices SC5xx machine type") Fixes: 03de305ec48b ("Restore patch series "arm: dts: am62-beagleplay:  Fix Beagleplay Ethernet"")
Reviewed-by: Quentin Schulz <quentin.schulz@cherry.de>
Reviewed-by: Greg Malysa <malysagreg@gmail.com>
(cherry picked from commit a98c640845626f42234abfd0c0af68a28b39199f)