### PR TITLE
checks: run qconfig sync for selected defconfigs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,10 @@ on:
       checkpatch_extraignores:
         type: string
         default: ""
+      defconfigs:
+        required: false
+        type: string
+        default: ""
     outputs:
       fatal:
         value: ${{ jobs.checks.outputs.fatal}}
@@ -74,15 +78,30 @@ jobs:
         [ $status -eq 124 ] && echo "step_fail_coccicheck_timeout=true" >> "$GITHUB_ENV"
         exit $status
 
-    - name: Check defconfigs
+    - name: Configure buildman toolchains
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        # Collect all defconfigs mentioned in the top-level and look for changes
-        configs=($(awk '/ARCH:/{arch=$2} /DEFCONFIG:/{print arch "/" $2}' \
-                   .github/workflows/top-level.yml | \
-                 sed 's/"//g'))
+        arm_gcc=$(basename "$(find /opt/gcc/armv7-eabihf/bin -maxdepth 1 -name '*gcc' | head -n 1)")
+        aarch64_gcc=$(basename "$(find /opt/gcc/aarch64/bin -maxdepth 1 -name '*gcc' | head -n 1)")
+
+        arm_prefix="/opt/gcc/armv7-eabihf/bin/${arm_gcc%gcc}"
+        aarch64_prefix="/opt/gcc/aarch64/bin/${aarch64_gcc%gcc}"
+
+        cat > "$HOME/.buildman" <<EOF
+        [toolchain-prefix]
+        arm = $arm_prefix
+        aarch64 = $aarch64_prefix
+        EOF
+
+    - name: Check qconfig
+      if: ${{ !cancelled() && env.fatal != 'true' }}
+      run: |
         source ./ci/build.sh
-        check_assert_defconfigs ${configs[@]}
+        list=$(mktemp)
+        cat > "$list" <<'EOF'
+        ${{ inputs.defconfigs }}
+        EOF
+        check_qconfig "$list"
 
     - name: Export labels
       if: ${{ !cancelled() }}

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -275,40 +275,49 @@ check_license() {
 	return $fail
 }
 
-check_assert_defconfigs() {
-	export step_name="check_assert_defconfigs"
+check_qconfig() {
+	export step_name="check_qconfig"
 	local fail=0
-	local arch
-	local defconfig
-	local file
+	local list="$1"
+	local out
+	local changed=0
 	local message="
-	Verify if the changes are coherent, for example, the changes were not
-	caused by a mistakenly set Kconfig, and if so, run 'make savedefconfig',
-	overwrite the defconfig and commit it.
+	Verify if the Kconfig/defconfig state is coherent for the selected CI defconfigs.
+	If qconfig.py updates files, run it locally for the affected configs,
+	inspect the result, and commit the necessary changes.
 	"
 
 	echo "$step_name"
-	for arg in "$@"; do
-		arch=$(cut -d "/" -f1 <<< "$arg")
-		[[ "$arch" == "arm64" ]] && arch_=aarch64 || arch_=$arch
-		defconfig=$(cut -d "/" -f2 <<< "$arg")
-		file=arch/$arch/configs/$defconfig
 
-		if [[ -f $file ]]; then
-			echo $file
-			set_arch gcc_$arch_ 1>/dev/null
-			make $defconfig savedefconfig 1>/dev/null
-			rm .config
+	python3 tools/qconfig.py -s -d "$list"
 
-			mv defconfig $file
-			out=$(git diff $_color --exit-code $file) || {
-				_fmt "::error file=$file::$step_name: Defconfig '$file' changed. $message
-				      $out"
-				fail=1
-			}
-			git restore $file
-		fi
-	done
+	out=$(git diff $_color --name-only)
+	if [[ -n "$out" ]]; then
+		while read -r file; do
+			[[ -z "$file" ]] && continue
+			_fmt "::error file=$(_file "$file")::$step_name: qconfig.py modified this file. $message"
+			changed=1
+		done <<< "$out"
+		fail=1
+	fi
+
+	out=$(git ls-files --others --exclude-standard)
+	if [[ -n "$out" ]]; then
+		while read -r file; do
+			[[ -z "$file" ]] && continue
+			[[ "$file" == "qconfig.failed" ]] && continue
+			[[ "$file" == "ci/build.sh" ]] && continue
+			[[ "$file" == "ci/runner_env.sh" ]] && continue
+			_fmt "::error file=$(_file "$file")::$step_name: qconfig.py created this untracked file. $message"
+			changed=1
+		done <<< "$out"
+		[[ "$changed" == "1" ]] && fail=1
+	fi
+
+	[[ "$changed" == "0" ]] && echo "qconfig.py produced no tree changes"
+
+	git restore .
+	git clean -fd -e ci/
 
 	return $fail
 }


### PR DESCRIPTION
Replace the defconfig assert step with a check_qconfig() helper
that runs qconfig.py on the selected defconfigs and reports any issues.