### PR TITLE
arm: sc5xx: add missing boot env selectors

### DIFF
--- a/board/adi/sc598-som-ezlite/sc598-som-ezlite.env
+++ b/board/adi/sc598-som-ezlite/sc598-som-ezlite.env
@@ -8,4 +8,10 @@ adi_image_offset=0x100000
 httpdstp=8000
 loadaddr=CONFIG_SC5XX_LOADADDR
 
+#define USE_NFS
+#define USE_SPI
+#define USE_RAM
+#define USE_MMC
+#define USE_USB
+
 #include <env/adi/adi_boot.env>


### PR DESCRIPTION
Define the boot options for SC598 SOM EZ-LITE so the shared ADI boot environment includes the expected boot commands for this board.

SC598 SOM EZ-LITE board environment utilizes the shared ADI boot environment, but it does not define any of the USE_* boot mode selectors. Without those selectors, the shared env does not generate the board boot commands such as `spiboot`. This leaves the default `bootcmd=run spiboot` without a matching environment command and breaks autoboot.

Fixes: 7210fc64fd86 ("board: adi: Add support for SC598")