### PR TITLE
arm: dts: add missing I2C controllers for sc59x

### DIFF
--- a/arch/arm/dts/sc573-ezlite.dts
+++ b/arch/arm/dts/sc573-ezlite.dts
@@ -14,6 +14,8 @@
 };
 
 &i2c0 {
+	status = "okay";
+
 	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;

--- a/arch/arm/dts/sc584-ezkit.dts
+++ b/arch/arm/dts/sc584-ezkit.dts
@@ -13,6 +13,8 @@
 };
 
 &i2c2 {
+	status = "okay";
+
 	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;

--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -17,6 +17,8 @@
 &i2c0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	status = "okay";
+
 	gpio_expander0: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;

--- a/arch/arm/dts/sc594-som.dtsi
+++ b/arch/arm/dts/sc594-som.dtsi
@@ -79,6 +79,7 @@
 
 &i2c2 {
 	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+	status = "okay";
 
 	som_gpio_expander: mcp23017@21 {
 		compatible = "microchip,mcp23017";
@@ -151,6 +152,18 @@
 			bootph-pre-ram;
 		};
 	};
+};
+
+&i2c3 {
+	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+};
+
+&i2c4 {
+	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+};
+
+&i2c5 {
+	clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
 };
 
 &ospi {

--- a/arch/arm/dts/sc598-som-revD.dtsi
+++ b/arch/arm/dts/sc598-som-revD.dtsi
@@ -8,6 +8,8 @@
 #include "sc598-som.dtsi"
 
 &i2c2 {
+	status = "okay";
+
 	som_gpio_expander: mcp23018@20 {
 		compatible = "microchip,mcp23018";
 		reg = <0x20>;

--- a/arch/arm/dts/sc598-som-revE.dtsi
+++ b/arch/arm/dts/sc598-som-revE.dtsi
@@ -8,6 +8,8 @@
 #include "sc598-som.dtsi"
 
 &i2c2 {
+	status = "okay";
+
 	som_gpio_expander: adp5587@34 {
 		compatible = "adi,adp5587";
 		reg = <0x34>;

--- a/arch/arm/dts/sc598-som.dtsi
+++ b/arch/arm/dts/sc598-som.dtsi
@@ -138,6 +138,18 @@
 	clocks = <&clk ADSP_SC598_CLK_CGU0_SCLK0>;
 };
 
+&i2c3 {
+	clocks = <&clk ADSP_SC598_CLK_CGU0_SCLK0>;
+};
+
+&i2c4 {
+	clocks = <&clk ADSP_SC598_CLK_CGU0_SCLK0>;
+};
+
+&i2c5 {
+	clocks = <&clk ADSP_SC598_CLK_CGU0_SCLK0>;
+};
+
 &spi2 {
 	clocks = <&clk ADSP_SC598_CLK_SPI>;
 };

--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -86,6 +86,36 @@
 			pinctrl-0 = <&usb0_default>;
 			status = "disabled";
 		};
+
+		i2c3: i2c3@31001000 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi-i2c";
+			reg = <0x31001000 0x100>;
+			clock-names = "i2c";
+			status = "disabled";
+			bootph-pre-ram;
+		};
+
+		i2c4: i2c4@31001100 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi-i2c";
+			reg = <0x31001100 0x100>;
+			clock-names = "i2c";
+			status = "disabled";
+			bootph-pre-ram;
+		};
+
+		i2c5: i2c5@31001200 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi-i2c";
+			reg = <0x31001200 0x100>;
+			clock-names = "i2c";
+			status = "disabled";
+			bootph-pre-ram;
+		};
 	};
 };
 

--- a/arch/arm/dts/sc5xx.dtsi
+++ b/arch/arm/dts/sc5xx.dtsi
@@ -140,9 +140,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi-i2c";
-			reg = <0x31001400 0x1000>;
+			reg = <0x31001400 0x100>;
 			clock-names = "i2c";
-			status = "okay";
+			status = "disabled";
 			bootph-pre-ram;
 		};
 
@@ -150,9 +150,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi-i2c";
-			reg = <0x31001500 0x1000>;
+			reg = <0x31001500 0x100>;
 			clock-names = "i2c";
-			status = "okay";
+			status = "disabled";
 			bootph-pre-ram;
 		};
 
@@ -160,9 +160,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi-i2c";
-			reg = <0x31001600 0x1000>;
+			reg = <0x31001600 0x100>;
 			clock-names = "i2c";
-			status = "okay";
+			status = "disabled";
 			bootph-pre-ram;
 		};
 	};


### PR DESCRIPTION
sc59x processors have 6 I2C controllers, but their devicetrees currently have only 3. Add missing I2C controllers and fix the existing ones.