### PR TITLE
board: adi: Fix exception when using standalone SoM

### DIFF
--- a/board/adi/carriers/somcrr_ezkit.c
+++ b/board/adi/carriers/somcrr_ezkit.c
@@ -13,13 +13,12 @@ void adi_somcrr_enable_ethernet(void)
 	struct gpio_desc *eth1_reset;
 	struct gpio_desc *gige_reset;
 
-	gpio_hog_lookup_name("eth1-en", &eth1);
-	gpio_hog_lookup_name("eth1-reset", &eth1_reset);
-	gpio_hog_lookup_name("gige-reset", &gige_reset);
-
-	dm_gpio_set_value(eth1, 1);
-	dm_gpio_set_value(eth1_reset, 0);
-	dm_gpio_set_value(gige_reset, 0);
+	if (!gpio_hog_lookup_name("eth1-en", &eth1))
+		dm_gpio_set_value(eth1, 1);
+	if (!gpio_hog_lookup_name("eth1-reset", &eth1_reset))
+		dm_gpio_set_value(eth1_reset, 0);
+	if (!gpio_hog_lookup_name("gige-reset", &gige_reset))
+		dm_gpio_set_value(gige_reset, 0);
 }
 
 void adi_somcrr_disable_ethernet(void)
@@ -28,11 +27,10 @@ void adi_somcrr_disable_ethernet(void)
 	struct gpio_desc *eth1_reset;
 	struct gpio_desc *gige_reset;
 
-	gpio_hog_lookup_name("eth1-en", &eth1);
-	gpio_hog_lookup_name("eth1-reset", &eth1_reset);
-	gpio_hog_lookup_name("gige-reset", &gige_reset);
-
-	dm_gpio_set_value(eth1, 0);
-	dm_gpio_set_value(eth1_reset, 1);
-	dm_gpio_set_value(gige_reset, 1);
+	if (!gpio_hog_lookup_name("eth1-en", &eth1))
+		dm_gpio_set_value(eth1, 0);
+	if (!gpio_hog_lookup_name("eth1-reset", &eth1_reset))
+		dm_gpio_set_value(eth1_reset, 1);
+	if (!gpio_hog_lookup_name("gige-reset", &gige_reset))
+		dm_gpio_set_value(gige_reset, 1);
 }

--- a/board/adi/carriers/somcrr_ezlite.c
+++ b/board/adi/carriers/somcrr_ezlite.c
@@ -11,14 +11,14 @@ void adi_somcrr_enable_ethernet(void)
 {
 	struct gpio_desc *gige_reset;
 
-	gpio_hog_lookup_name("eth0-reset", &gige_reset);
-	dm_gpio_set_value(gige_reset, 0);
+	if (!gpio_hog_lookup_name("eth0-reset", &gige_reset))
+		dm_gpio_set_value(gige_reset, 0);
 }
 
 void adi_somcrr_disable_ethernet(void)
 {
 	struct gpio_desc *gige_reset;
 
-	gpio_hog_lookup_name("eth0-reset", &gige_reset);
-	dm_gpio_set_value(gige_reset, 1);
+	if (!gpio_hog_lookup_name("eth0-reset", &gige_reset))
+		dm_gpio_set_value(gige_reset, 1);
 }


### PR DESCRIPTION
Although less common, ADSP SoM boards can be operated standalone without a carrier board. The SoM can be powered over USB-C by moving the jumper on JP1.

The board configuration needs to be heavily refactored to reduce the number of defconfigs and leverage the devicetree. The TI DP83867 support, which is dependent on that configuration, needs to be removed. Until then this change allows the same U-Boot binary to work correctly both with carrier boards and the standalone SoM.

The carrier board initialization code in somcrr_ezkit.c and somcrr_ezlite.c calls gpio_hog_lookup_name() to find ethernet control GPIOs, but does not check if the lookup succeeds before using the returned pointers.

When running on a standalone SoM without a carrier board, these GPIO hogs do not exist in the device tree. The gpio_hog_lookup_name() function returns -ENODEV and sets the pointer to NULL, but the code continues to call dm_gpio_set_value() with uninitialized pointers, causing a synchronous abort exception:

  "Synchronous Abort" handler, esr 0x96000004
  elr: 00000000960326c4 lr : 0000000096038d5c (reloc)