### PR TITLE
spi: uclass: skip cs lookup if bus not probed

### DIFF
--- a/drivers/spi/spi-uclass.c
+++ b/drivers/spi/spi-uclass.c
@@ -203,6 +203,17 @@ static int spi_child_pre_probe(struct udevice *dev)
 {
 	struct dm_spi_slave_plat *plat = dev_get_parent_plat(dev);
 	struct spi_slave *slave = dev_get_parent_priv(dev);
+	struct udevice *bus = dev_get_parent(dev);
+	struct dm_spi_ops *ops = spi_get_ops(bus);
+	int ret;
+
+	if (ops->cs_info) {
+		ret = ops->cs_info(bus, plat->cs[0], NULL);
+		if (ret) {
+			dev_err(dev, "Invalid chip select %u\n", plat->cs[0]);
+			return ret;
+		}
+	}
 
 	/*
 	 * This is needed because we pass struct spi_slave around the place
@@ -229,32 +240,7 @@ int spi_chip_select(struct udevice *dev)
 
 int spi_find_chip_select(struct udevice *bus, int cs, struct udevice **devp)
 {
-	struct dm_spi_ops *ops;
-	struct spi_cs_info info;
 	struct udevice *dev;
-	int ret;
-
-	/*
-	 * Ask the driver. For the moment we don't have CS info.
-	 * When we do we could provide the driver with a helper function
-	 * to figure out what chip selects are valid, or just handle the
-	 * request.
-	 */
-	ops = spi_get_ops(bus);
-	if (ops->cs_info) {
-		ret = ops->cs_info(bus, cs, &info);
-	} else {
-		/*
-		 * We could assume there is at least one valid chip select.
-		 * The driver didn't care enough to tell us.
-		 */
-		ret = 0;
-	}
-
-	if (ret) {
-		dev_err(bus, "Invalid cs %d (err=%d)\n", cs, ret);
-		return ret;
-	}
 
 	for (device_find_first_child(bus, &dev); dev;
 	     device_find_next_child(&dev)) {


### PR DESCRIPTION
spi_find_bus_and_cs() uses uclass_find_device_by_seq() which locates the bus without probing it. Calling spi_find_chip_select() on an unprobed bus causes drivers that validate chip selects using private data (initialized only at probe time) to spuriously reject valid CS numbers. Since no SPI device can exist on an unprobed bus, return -ENODEV early instead.

```
U-Boot SPL 2025.10 (May 04 2026 - 12:40:02 -0400)
ADI Boot Mode: 0x1 (QSPI Master)
Trying to boot from BOOTROM


U-Boot 2025.10 (May 04 2026 - 12:40:02 -0400)

CPU:   ADSP ADSP-SC598-0.0 (QSPI Master boot)
Model: ADI SC598-SOM-EZKIT
DRAM:  224 MiB
ADP558x Detected: Rev 4, Rev ID 4
Core:  139 devices, 23 uclasses, devicetree: embed
MMC:   mmc@310C7000: 0
Loading Environment from nowhere... OK
In:    serial@0x31003000
Out:   serial@0x31003000
Err:   serial@0x31003000
Net:   eth0: eth0
=> sf probe
adi_spi3 spi2: invalid chipselect 1
adi_spi3 spi2: Invalid cs 1 (err=-22)
SF: Detected is25lp01g with page size 256 Bytes, erase size 4 KiB, total 128 MiB
=>
```