### PR TITLE
watchdog: adi: fix WDOG_CNT calculation

### DIFF
--- a/drivers/watchdog/adi_wdt.c
+++ b/drivers/watchdog/adi_wdt.c
@@ -80,9 +80,8 @@ static int adi_wdt_start(struct udevice *dev, u64 timeout_ms, ulong flags)
 	/* enable watchdog0 */
 	iowrite32(WDDIS, priv->wdt_base + WDOG_CTL);
 
-	iowrite32(timeout_ms / 1000 *
-	       (clk_get_rate(&priv->clock) / (IS_ENABLED(CONFIG_SC58X) ? 2 : 1)),
-	       priv->wdt_base + WDOG_CNT);
+	iowrite32((u64)timeout_ms * clk_get_rate(&priv->clock) / 1000,
+		  priv->wdt_base + WDOG_CNT);
 
 	iowrite32(0, priv->wdt_base + WDOG_STAT);
 	iowrite32(WDEN, priv->wdt_base + WDOG_CTL);


### PR DESCRIPTION
Fix two bugs in the timeout count calculation:
- Integer truncation: timeout_ms / 1000 * clk_rate loses sub-second precision; reorder to multiply first in u64 before dividing.
- Incorrect divide by 2 for SC58X: WDOG_CNT decrements once per cycle of SCLK0_0 clock.

This should fix issue #95 