### PR TITLE
.github/build: Add shared action

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -8,48 +8,12 @@ on:
         type: string
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  build:
+    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      arch: arm64
+      defconfig: ${{ inputs.defconfig }}
 
-      - name: Install aarch64 toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgnutls28-dev
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Install ADSP LDR
-        run: |
-          sudo apt-get install -y libusb-1.0-0-dev
-          pip install meson
-          curl -LO https://github.com/analogdevicesinc/adsp-ldr/releases/download/v1.0.1/adsp-ldr-v1.0.1.tar.xz
-          tar -xf adsp-ldr-v1.0.1.tar.xz
-          cd adsp-ldr-v1.0.1
-          meson setup builddir
-          cd builddir
-          meson install
-          ln -s /usr/local/bin/ldr /usr/local/bin/aarch64-linux-gnu-ldr
-
-      - name: Build U-Boot
-        run: |
-          echo ${PATH}
-          export CROSS_COMPILE="aarch64-linux-gnu-"
-          sudo apt-get install -y device-tree-compiler uuid-dev
-          make ${{ inputs.defconfig }}
-          make -j$(nproc)
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: u-boot-${{ inputs.defconfig }}
-          path: |
-            u-boot
-            u-boot.elf
-            u-boot.bin
-            u-boot.ldr
-            spl/u-boot-spl
-            spl/u-boot-spl.bin
-            spl/u-boot-spl.ldr
-          retention-days: 7

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -8,47 +8,12 @@ on:
         type: string
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  build:
+    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      arch: arm
+      defconfig: ${{ inputs.defconfig }}
 
-      - name: Install ARM toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgnutls28-dev
-          sudo apt-get install -y gcc-arm-none-eabi
-
-      - name: Install ADSP LDR
-        run: |
-          sudo apt-get install -y libusb-1.0-0-dev
-          pip install meson
-          curl -LO https://github.com/analogdevicesinc/adsp-ldr/releases/download/v1.0.1/adsp-ldr-v1.0.1.tar.xz
-          tar -xf adsp-ldr-v1.0.1.tar.xz
-          cd adsp-ldr-v1.0.1
-          meson setup builddir
-          cd builddir
-          meson install
-          ln -s /usr/local/bin/ldr /usr/local/bin/arm-none-eabi-ldr
-
-      - name: Build U-Boot
-        run: |
-          echo ${PATH}
-          export CROSS_COMPILE="arm-none-eabi-"
-          make ${{ inputs.defconfig }}
-          make -j$(nproc)
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: u-boot-${{ inputs.defconfig }}
-          path: |
-            u-boot
-            u-boot.elf
-            u-boot.bin
-            u-boot.ldr
-            spl/u-boot-spl
-            spl/u-boot-spl.bin
-            spl/u-boot-spl.ldr
-          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Build U-Boot
 
 on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: "Architecture (arm, arm64)"
+        required: true
+        type: string
+      defconfig:
+        description: "Defconfig (sc584-ezkit_defconfig, ...)"
+        required: true
+        type: string
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: Build U-Boot
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      defconfig:
+        required: true
+        type: string
+
+jobs:
+  setup:
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgnutls28-dev \
+            device-tree-compiler uuid-dev
+          if [[ "${{ inputs.arch }}" == "arm" ]]; then
+            sudo apt-get install -y gcc-arm-none-eabi
+          elif [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+          fi
+
+      - name: Install ADSP LDR
+        run: |
+          sudo apt-get install -y libusb-1.0-0-dev
+          pip install meson
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -O \
+            https://github.com/analogdevicesinc/adsp-ldr/releases/download/v1.0.1/adsp-ldr-v1.0.1.tar.xz
+          tar -xf adsp-ldr-v1.0.1.tar.xz
+          cd adsp-ldr-v1.0.1
+          meson setup builddir
+          cd builddir
+          meson install
+          if [[ "${{ inputs.arch }}" == "arm" ]]; then
+            ln -s /usr/local/bin/ldr /usr/local/bin/arm-none-eabi-ldr
+          elif [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            ln -s /usr/local/bin/ldr /usr/local/bin/aarch64-linux-gnu-ldr
+          fi
+
+      - name: Build U-Boot
+        run: |
+          echo ${PATH}
+          if [[ "${{ inputs.arch }}" == "arm" ]]; then
+            export CROSS_COMPILE="arm-none-eabi-"
+          elif [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            export CROSS_COMPILE="aarch64-linux-gnu-"
+          fi
+          make "${{ inputs.defconfig }}"
+          make -j$(nproc)
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: u-boot-${{ inputs.defconfig }}
+          path: |
+            u-boot
+            u-boot.elf
+            u-boot.bin
+            u-boot.ldr
+            spl/u-boot-spl
+            spl/u-boot-spl.bin
+            spl/u-boot-spl.ldr
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libgnutls28-dev \
-            device-tree-compiler uuid-dev
+            device-tree-compiler uuid-dev \
+            libusb-1.0-0
           if [[ "${{ inputs.arch }}" == "arm" ]]; then
             sudo apt-get install -y gcc-arm-none-eabi
           elif [[ "${{ inputs.arch }}" == "arm64" ]]; then
@@ -33,19 +34,13 @@ jobs:
 
       - name: Install ADSP LDR
         run: |
-          sudo apt-get install -y libusb-1.0-0-dev
-          pip install meson
-          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -O \
-            https://github.com/analogdevicesinc/adsp-ldr/releases/download/v1.0.1/adsp-ldr-v1.0.1.tar.xz
-          tar -xf adsp-ldr-v1.0.1.tar.xz
-          cd adsp-ldr-v1.0.1
-          meson setup builddir
-          cd builddir
-          meson install
+          curl -LO https://packages.analog.com/public/deb/ubuntu/pool/any-version/main/a/ad/adsp-ldr_1.0.2/adsp-ldr_1.0.2_amd64.deb
+          sudo apt-get install -y ./adsp-ldr_1.0.2_amd64.deb
+
           if [[ "${{ inputs.arch }}" == "arm" ]]; then
-            ln -s /usr/local/bin/ldr /usr/local/bin/arm-none-eabi-ldr
+            ln -s /usr/bin/ldr /usr/bin/arm-none-eabi-ldr
           elif [[ "${{ inputs.arch }}" == "arm64" ]]; then
-            ln -s /usr/local/bin/ldr /usr/local/bin/aarch64-linux-gnu-ldr
+            ln -s /usr/bin/ldr /usr/bin/aarch64-linux-gnu-ldr
           fi
 
       - name: Build U-Boot


### PR DESCRIPTION
Adds 'inputs.arch' to support multiple architectures.
Reduce code duplication by using a single action with multi-arch
support.
