### PR TITLE
Align ADSP SC5XX gpio DTS and driver with Linux

### DIFF
--- a/arch/arm/dts/sc573-ezlite.dts
+++ b/arch/arm/dts/sc573-ezlite.dts
@@ -226,14 +226,14 @@
 };
 
 &eth0 {
-	snps,reset-gpio = <&gpio0 ADI_ADSP_PIN('A', 5) GPIO_ACTIVE_LOW>;
+	snps,reset-gpio = <&gpa 5 GPIO_ACTIVE_LOW>;
 };
 
-&gpio0 {
+&gpa {
 	emac0_phy_pwdn {
 		gpio-hog;
 		output-high;
-		gpios = <ADI_ADSP_PIN('A', 4) GPIO_ACTIVE_HIGH>;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/arch/arm/dts/sc57x.dtsi
+++ b/arch/arm/dts/sc57x.dtsi
@@ -94,8 +94,19 @@
 	adi,npins = <92>;
 };
 
-&gpio0 {
-	adi,ngpios = <92>;
+/ {
+	scb {
+		gpf: gpio@31004280 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004280 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "F";
+			adi,ngpios = <12>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+	};
 };
 
 &clk {

--- a/arch/arm/dts/sc57x.dtsi
+++ b/arch/arm/dts/sc57x.dtsi
@@ -102,7 +102,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "F";
-			adi,ngpios = <12>;
+			ngpios = <12>;
 			status = "okay";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc584-ezkit.dts
+++ b/arch/arm/dts/sc584-ezkit.dts
@@ -233,13 +233,13 @@
 };
 
 &eth0 {
-	snps,reset-gpio = <&gpio0 ADI_ADSP_PIN('B', 14) GPIO_ACTIVE_LOW>;
+	snps,reset-gpio = <&gpb 14 GPIO_ACTIVE_LOW>;
 };
 
-&gpio0 {
+&gpc {
 	emac0_phy_pwdn {
 		gpio-hog;
 		output-high;
-		gpios = <ADI_ADSP_PIN('C', 15) GPIO_ACTIVE_HIGH>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -197,14 +197,14 @@
 };
 
 &eth0 {
-	snps,reset-gpio = <&gpio0 ADI_ADSP_PIN('B', 14) GPIO_ACTIVE_LOW>;
+	snps,reset-gpio = <&gpb 14 GPIO_ACTIVE_LOW>;
 };
 
-&gpio0 {
+&gpc {
 	emac0_phy_pwdn {
 		gpio-hog;
 		output-high;
-		gpios = <ADI_ADSP_PIN('C', 15) GPIO_ACTIVE_HIGH>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/arch/arm/dts/sc589-mini.dts
+++ b/arch/arm/dts/sc589-mini.dts
@@ -13,14 +13,14 @@
 };
 
 &eth0 {
-	snps,reset-gpio = <&gpio0 ADI_ADSP_PIN('B', 7) GPIO_ACTIVE_LOW>;
+	snps,reset-gpio = <&gpb 7 GPIO_ACTIVE_LOW>;
 };
 
-&gpio0 {
+&gpf {
 	emac0_phy_pwdn {
 		gpio-hog;
 		output-high;
-		gpios = <ADI_ADSP_PIN('F', 6) GPIO_ACTIVE_HIGH>;
+		gpios = <6 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/arch/arm/dts/sc58x.dtsi
+++ b/arch/arm/dts/sc58x.dtsi
@@ -128,8 +128,30 @@
 	adi,npins = <102>;
 };
 
-&gpio0 {
-	adi,ngpios = <102>;
+/ {
+	scb {
+		gpf: gpio@31004280 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004280 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "F";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpg: gpio@31004300 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004300 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "G";
+			adi,ngpios = <6>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+	};
 };
 
 &clk {

--- a/arch/arm/dts/sc58x.dtsi
+++ b/arch/arm/dts/sc58x.dtsi
@@ -136,7 +136,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "F";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -147,7 +147,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "G";
-			adi,ngpios = <6>;
+			ngpios = <6>;
 			status = "okay";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc598-htol.dts
+++ b/arch/arm/dts/sc598-htol.dts
@@ -21,7 +21,7 @@
 			clock-names = "sclk0";
 			linux,rs485-enabled-at-boot-time;
 			rs485-rts-active-low;
-			rts-gpios = <&gpio0 ADI_ADSP_PIN('D', 1) GPIO_ACTIVE_HIGH>;
+			rts-gpios = <&gpd 1 GPIO_ACTIVE_HIGH>;
 			status = "okay";
 		};
 	};
@@ -34,10 +34,10 @@
 	};
 };
 
-&gpio0 {
+&gpb {
 	uart0-en {
 		gpio-hog;
-		gpios = <ADI_ADSP_PIN('B', 13) GPIO_ACTIVE_LOW>;
+		gpios = <13 GPIO_ACTIVE_LOW>;
 		output-high;
 		line-name = "uart0-en";
 		bootph-pre-ram;
@@ -45,22 +45,24 @@
 
 	uart0-flow-en {
 		gpio-hog;
-		gpios = <ADI_ADSP_PIN('B', 14) GPIO_ACTIVE_LOW>;
+		gpios = <14 GPIO_ACTIVE_LOW>;
 		output-low;
 		line-name = "uart0-flow-en";
 		bootph-pre-ram;
 	};
+};
 
+&gpe {
 	led1 {
 		gpio-hog;
-		gpios = <ADI_ADSP_PIN('E', 15) GPIO_ACTIVE_LOW>;
+		gpios = <15 GPIO_ACTIVE_LOW>;
 		output-high;
 		line-name = "led1";
 	};
 
 	led2 {
 		gpio-hog;
-		gpios = <ADI_ADSP_PIN('E', 10) GPIO_ACTIVE_LOW>;
+		gpios = <10 GPIO_ACTIVE_LOW>;
 		output-high;
 		line-name = "led2";
 	};

--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -192,7 +192,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "F";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -203,7 +203,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "G";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -214,7 +214,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "H";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -225,7 +225,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "I";
-			adi,ngpios = <7>;
+			ngpios = <7>;
 			status = "okay";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -9,9 +9,9 @@
 		spi0 = "/ospi";
 	};
 
-	soc {
+	scb {
 		rcu: rcu@0x3108C000 {
-			compatible = "adi,reset-controller";
+			compatible = "adi,reset-controller", "syscon";
 			reg = <0x3108C000 0x1000>;
 			adi,sharc-min = <1>;
 			adi,sharc-max = <2>;
@@ -69,9 +69,7 @@
 		usb0_phy: usbphy {
 			compatible = "usb-nop-xceiv";
 			#phy-cells = <0>;
-			reset = <&gpio0 ADI_ADSP_PIN('G', 11) GPIO_ACTIVE_HIGH>;
-			pinctrl-names = "default";
-			pinctrl-0 = <&usb0_default>;
+			reset-gpios = <&gpg 11 GPIO_ACTIVE_LOW>;
 			status = "disabled";
 		};
 
@@ -90,9 +88,9 @@
 		i2c3: i2c3@31001000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001000 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -100,9 +98,9 @@
 		i2c4: i2c4@31001100 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001100 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -110,9 +108,9 @@
 		i2c5: i2c5@31001200 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001200 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -186,20 +184,68 @@
 	};
 };
 
-&gpio0 {
-	adi,ngpios = <135>;
+/ {
+	scb {
+		gpf: gpio@31004280 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004280 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "F";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
 
+		gpg: gpio@31004300 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004300 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "G";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gph: gpio@31004380 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004380 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "H";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpi: gpio@31004400 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004400 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "I";
+			adi,ngpios = <7>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+	};
+};
+
+&gpd {
 	pushbutton0 {
 		gpio-hog;
 		input;
-		gpios = <ADI_ADSP_PIN('D', 0) GPIO_ACTIVE_HIGH>;
+		gpios = <0 GPIO_ACTIVE_HIGH>;
 		bootph-pre-ram;
 	};
+};
 
+&gph {
 	pushbutton1 {
 		gpio-hog;
 		input;
-		gpios = <ADI_ADSP_PIN('H', 0) GPIO_ACTIVE_HIGH>;
+		gpios = <0 GPIO_ACTIVE_HIGH>;
 		bootph-pre-ram;
 	};
 };

--- a/arch/arm/dts/sc5xx.dtsi
+++ b/arch/arm/dts/sc5xx.dtsi
@@ -77,7 +77,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "A";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -88,7 +88,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "B";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -99,7 +99,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "C";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -110,7 +110,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "D";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};
@@ -121,7 +121,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			adi,bank-name = "E";
-			adi,ngpios = <16>;
+			ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc5xx.dtsi
+++ b/arch/arm/dts/sc5xx.dtsi
@@ -71,11 +71,57 @@
 			bootph-pre-ram;
 		};
 
-		gpio0: gpio@0x31004000 {
-			compatible = "adi,adsp-gpio";
-			reg = <0x31004000 0x500>;
+		gpa: gpio@31004000 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004000 0x80>;
 			gpio-controller;
 			#gpio-cells = <2>;
+			adi,bank-name = "A";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpb: gpio@31004080 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004080 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "B";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpc: gpio@31004100 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004100 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "C";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpd: gpio@31004180 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004180 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "D";
+			adi,ngpios = <16>;
+			status = "okay";
+			bootph-pre-ram;
+		};
+
+		gpe: gpio@31004200 {
+			compatible = "adi,adsp-port-gpio";
+			reg = <0x31004200 0x80>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			adi,bank-name = "E";
+			adi,ngpios = <16>;
 			status = "okay";
 			bootph-pre-ram;
 		};

--- a/drivers/gpio/gpio-adi-adsp.c
+++ b/drivers/gpio/gpio-adi-adsp.c
@@ -13,27 +13,24 @@
 #include <linux/bitops.h>
 #include <linux/io.h>
 
-#define ADSP_PORT_MMIO_SIZE		0x80
-#define ADSP_PORT_PIN_SIZE		16
-
-#define ADSP_PORT_REG_FER			0x00
+#define ADSP_PORT_REG_FER		0x00
 #define ADSP_PORT_REG_FER_SET		0x04
 #define ADSP_PORT_REG_FER_CLEAR		0x08
-#define ADSP_PORT_REG_DATA			0x0c
+#define ADSP_PORT_REG_DATA		0x0c
 #define ADSP_PORT_REG_DATA_SET		0x10
 #define ADSP_PORT_REG_DATA_CLEAR	0x14
-#define ADSP_PORT_REG_DIR			0x18
+#define ADSP_PORT_REG_DIR		0x18
 #define ADSP_PORT_REG_DIR_SET		0x1c
 #define ADSP_PORT_REG_DIR_CLEAR		0x20
-#define ADSP_PORT_REG_INEN			0x24
+#define ADSP_PORT_REG_INEN		0x24
 #define ADSP_PORT_REG_INEN_SET		0x28
 #define ADSP_PORT_REG_INEN_CLEAR	0x2c
 #define ADSP_PORT_REG_PORT_MUX		0x30
 #define ADSP_PORT_REG_DATA_TGL		0x34
-#define ADSP_PORT_REG_POLAR			0x38
+#define ADSP_PORT_REG_POLAR		0x38
 #define ADSP_PORT_REG_POLAR_SET		0x3c
 #define ADSP_PORT_REG_POLAR_CLEAR	0x40
-#define ADSP_PORT_REG_LOCK			0x44
+#define ADSP_PORT_REG_LOCK		0x44
 #define ADSP_PORT_REG_TRIG_TGL		0x48
 
 struct adsp_gpio_priv {
@@ -41,106 +38,70 @@ struct adsp_gpio_priv {
 	int ngpio;
 };
 
-static u32 get_port(unsigned int pin)
-{
-	return pin / ADSP_PORT_PIN_SIZE;
-}
-
-static u32 get_offset(unsigned int pin)
-{
-	return pin % ADSP_PORT_PIN_SIZE;
-}
-
 static int adsp_gpio_input(struct udevice *udev, unsigned int pin)
 {
 	struct adsp_gpio_priv *priv = dev_get_priv(udev);
-	u32 port, offset;
-	void __iomem *portbase;
 
-	if (pin < priv->ngpio) {
-		port = get_port(pin);
-		offset = get_offset(pin);
-		portbase = priv->base + port * ADSP_PORT_MMIO_SIZE;
+	if (pin >= priv->ngpio)
+		return -EINVAL;
 
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_FER_CLEAR);
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DIR_CLEAR);
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_INEN_SET);
-		return 0;
-	}
-
-	return -EINVAL;
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_FER_CLEAR);
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DIR_CLEAR);
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_INEN_SET);
+	return 0;
 }
 
 static int adsp_gpio_output(struct udevice *udev, unsigned int pin, int value)
 {
 	struct adsp_gpio_priv *priv = dev_get_priv(udev);
-	u32 port, offset;
-	void __iomem *portbase;
 
-	if (pin < priv->ngpio) {
-		port = get_port(pin);
-		offset = get_offset(pin);
-		portbase = priv->base + port * ADSP_PORT_MMIO_SIZE;
+	if (pin >= priv->ngpio)
+		return -EINVAL;
 
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_FER_CLEAR);
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_FER_CLEAR);
 
-		if (value)
-			iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DATA_SET);
-		else
-			iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DATA_CLEAR);
+	if (value)
+		iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DATA_SET);
+	else
+		iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DATA_CLEAR);
 
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DIR_SET);
-		iowrite16(BIT(offset), portbase + ADSP_PORT_REG_INEN_CLEAR);
-		return 0;
-	}
-
-	return -EINVAL;
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DIR_SET);
+	iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_INEN_CLEAR);
+	return 0;
 }
 
 static int adsp_gpio_get_value(struct udevice *udev, unsigned int pin)
 {
 	struct adsp_gpio_priv *priv = dev_get_priv(udev);
-	u32 port, offset;
 	u16 val;
-	void __iomem *portbase;
 
-	if (pin < priv->ngpio) {
-		port = get_port(pin);
-		offset = get_offset(pin);
-		portbase = priv->base + port * ADSP_PORT_MMIO_SIZE;
+	if (pin >= priv->ngpio)
+		return 0;
 
-		val = ioread16(portbase + ADSP_PORT_REG_DATA);
-		return !!(val & BIT(offset));
-	}
-
-	return 0;
+	val = ioread16(priv->base + ADSP_PORT_REG_DATA);
+	return !!(val & BIT(pin));
 }
 
 static int adsp_gpio_set_value(struct udevice *udev, unsigned int pin, int value)
 {
 	struct adsp_gpio_priv *priv = dev_get_priv(udev);
-	u32 port, offset;
-	void __iomem *portbase;
 
-	if (pin < priv->ngpio) {
-		port = get_port(pin);
-		offset = get_offset(pin);
-		portbase = priv->base + port * ADSP_PORT_MMIO_SIZE;
+	if (pin >= priv->ngpio)
+		return 0;
 
-		if (value)
-			iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DATA_SET);
-		else
-			iowrite16(BIT(offset), portbase + ADSP_PORT_REG_DATA_CLEAR);
-	}
+	if (value)
+		iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DATA_SET);
+	else
+		iowrite16(BIT(pin), priv->base + ADSP_PORT_REG_DATA_CLEAR);
 
 	return 0;
 }
 
 static const struct dm_gpio_ops adsp_gpio_ops = {
-	.direction_input = adsp_gpio_input,
+	.direction_input  = adsp_gpio_input,
 	.direction_output = adsp_gpio_output,
-	.get_value = adsp_gpio_get_value,
-	.set_value = adsp_gpio_set_value,
+	.get_value        = adsp_gpio_get_value,
+	.set_value        = adsp_gpio_set_value,
 };
 
 static int adsp_gpio_probe(struct udevice *udev)
@@ -148,11 +109,13 @@ static int adsp_gpio_probe(struct udevice *udev)
 	struct adsp_gpio_priv *priv = dev_get_priv(udev);
 	struct gpio_dev_priv *uc_priv = dev_get_uclass_priv(udev);
 
-	uc_priv->bank_name = "adsp gpio";
+	uc_priv->bank_name = dev_read_string(udev, "adi,bank-name");
+	if (!uc_priv->bank_name)
+		uc_priv->bank_name = udev->name;
 	uc_priv->gpio_count = dev_read_u32_default(udev, "adi,ngpios", 0);
 
 	if (!uc_priv->gpio_count) {
-		dev_err(udev, "Missing adi,ngpios property!\n");
+		dev_err(udev, "missing adi,ngpios property\n");
 		return -ENOENT;
 	}
 
@@ -163,16 +126,16 @@ static int adsp_gpio_probe(struct udevice *udev)
 }
 
 static const struct udevice_id adsp_gpio_match[] = {
-	{ .compatible = "adi,adsp-gpio" },
+	{ .compatible = "adi,adsp-port-gpio" },
 	{ },
 };
 
 U_BOOT_DRIVER(adi_adsp_gpio) = {
-	.name	= "adi_adsp_gpio",
-	.id	= UCLASS_GPIO,
-	.ops	= &adsp_gpio_ops,
-	.probe	= adsp_gpio_probe,
+	.name      = "adi_adsp_gpio",
+	.id        = UCLASS_GPIO,
+	.ops       = &adsp_gpio_ops,
+	.probe     = adsp_gpio_probe,
 	.priv_auto = sizeof(struct adsp_gpio_priv),
-	.of_match = adsp_gpio_match,
-	.flags = DM_FLAG_PRE_RELOC,
+	.of_match  = adsp_gpio_match,
+	.flags     = DM_FLAG_PRE_RELOC,
 };

--- a/drivers/gpio/gpio-adi-adsp.c
+++ b/drivers/gpio/gpio-adi-adsp.c
@@ -112,10 +112,10 @@ static int adsp_gpio_probe(struct udevice *udev)
 	uc_priv->bank_name = dev_read_string(udev, "adi,bank-name");
 	if (!uc_priv->bank_name)
 		uc_priv->bank_name = udev->name;
-	uc_priv->gpio_count = dev_read_u32_default(udev, "adi,ngpios", 0);
+	uc_priv->gpio_count = dev_read_u32_default(udev, "ngpios", 0);
 
 	if (!uc_priv->gpio_count) {
-		dev_err(udev, "missing adi,ngpios property\n");
+		dev_err(udev, "missing ngpios property\n");
 		return -ENOENT;
 	}
 


### PR DESCRIPTION
This PR is for aligning ADSP SC5XX gpio DTS and driver with Linux. It does two things:

1. Replace the single gpio0 node (covering all ports via stride calculation) with individual per-port nodes gpa–gpi, matching the Linux DTS binding.

2. Replace the ADI-specific adi,ngpios with the standard ngpios property