### PR TITLE
Align ADSP SC5XX i2c DTS and driver with Linux

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -638,7 +638,7 @@ F:	drivers/clk/adi/
 F:	drivers/dma/adi_dma.c
 F:	drivers/gpio/adp5588_gpio.c
 F:	drivers/gpio/gpio-adi-adsp.c
-F:	drivers/i2c/adi_i2c.c
+F:	drivers/i2c/adi_twi.c
 F:	drivers/mmc/adi_sdhci.c
 F:	drivers/net/dwc_eth_qos_adi.c
 F:	drivers/pinctrl/pinctrl-adi-adsp.c

--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -90,7 +90,7 @@
 		i2c3: i2c3@31001000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001000 0x100>;
 			clock-names = "i2c";
 			status = "disabled";
@@ -100,7 +100,7 @@
 		i2c4: i2c4@31001100 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001100 0x100>;
 			clock-names = "i2c";
 			status = "disabled";
@@ -110,7 +110,7 @@
 		i2c5: i2c5@31001200 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001200 0x100>;
 			clock-names = "i2c";
 			status = "disabled";

--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -92,7 +92,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001000 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -102,7 +102,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001100 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -112,7 +112,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001200 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc5xx.dtsi
+++ b/arch/arm/dts/sc5xx.dtsi
@@ -141,7 +141,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001400 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -151,7 +151,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001500 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};
@@ -161,7 +161,7 @@
 			#size-cells = <0>;
 			compatible = "adi,twi";
 			reg = <0x31001600 0x100>;
-			clock-names = "i2c";
+			clock-names = "sclk0";
 			status = "disabled";
 			bootph-pre-ram;
 		};

--- a/arch/arm/dts/sc5xx.dtsi
+++ b/arch/arm/dts/sc5xx.dtsi
@@ -139,7 +139,7 @@
 		i2c0: i2c0@31001400 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001400 0x100>;
 			clock-names = "i2c";
 			status = "disabled";
@@ -149,7 +149,7 @@
 		i2c1: i2c1@31001500 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001500 0x100>;
 			clock-names = "i2c";
 			status = "disabled";
@@ -159,7 +159,7 @@
 		i2c2: i2c2@31001600 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "adi-i2c";
+			compatible = "adi,twi";
 			reg = <0x31001600 0x100>;
 			clock-names = "i2c";
 			status = "disabled";

--- a/doc/develop/driver-model/i2c-howto.rst
+++ b/doc/develop/driver-model/i2c-howto.rst
@@ -6,7 +6,7 @@ How to port an I2C driver to driver model
 Over half of the I2C drivers have been converted as at November 2016. These
 ones remain:
 
-   * adi_i2c
+   * adi_twi
    * davinci_i2c
    * fti2c010
    * ihs_i2c

--- a/drivers/i2c/Makefile
+++ b/drivers/i2c/Makefile
@@ -11,7 +11,7 @@ obj-$(CONFIG_$(PHASE_)I2C_CROS_EC_TUNNEL) += cros_ec_tunnel.o
 obj-$(CONFIG_$(PHASE_)I2C_CROS_EC_LDO) += cros_ec_ldo.o
 
 obj-$(CONFIG_$(PHASE_)SYS_I2C_LEGACY) += i2c_core.o
-obj-$(CONFIG_SYS_I2C_ADI) += adi_i2c.o
+obj-$(CONFIG_SYS_I2C_ADI) += adi_twi.o
 obj-$(CONFIG_SYS_I2C_ASPEED) += ast_i2c.o
 obj-$(CONFIG_SYS_I2C_AST2600) += ast2600_i2c.o
 obj-$(CONFIG_SYS_I2C_AT91) += at91_i2c.o

--- a/drivers/i2c/adi_twi.c
+++ b/drivers/i2c/adi_twi.c
@@ -297,7 +297,7 @@ static int adi_i2c_of_to_plat(struct udevice *bus)
 	dev->speed = dev_read_u32_default(bus, "clock-frequency",
 					  I2C_SPEED_FAST_RATE);
 
-	ret = clk_get_by_name(bus, "i2c", &clock);
+	ret = clk_get_by_name(bus, "sclk0", &clock);
 	if (ret < 0)
 		printf("%s: Can't get I2C clk: %d\n", __func__, ret);
 	else

--- a/drivers/i2c/adi_twi.c
+++ b/drivers/i2c/adi_twi.c
@@ -368,7 +368,7 @@ static const struct dm_i2c_ops adi_i2c_ops = {
 };
 
 static const struct udevice_id adi_i2c_ids[] = {
-	{ .compatible = "adi-i2c", },
+	{ .compatible = "adi,twi", },
 	{ /* sentinel */ }
 };
 


### PR DESCRIPTION
This PR is for aligning ADSP SC5XX i2c DTS and driver with Linux. It does two things:

1. Rename adi_i2c.c to adi_twi.c and update the compatible string from "adi-i2c" to "adi,twi" to match the Linux kernel driver

2. Use sclk0 instead of i2c as clock-names for i2c to match linux kernel.