### PR TITLE
spi: adi_spi3: remove spurious 500 kHz controller speed cap

### DIFF
--- a/drivers/spi/adi_spi3.c
+++ b/drivers/spi/adi_spi3.c
@@ -289,7 +289,7 @@ static int adi_spi_of_to_plat(struct udevice *bus)
 	struct adi_spi_platdata *plat = dev_get_plat(bus);
 	fdt_addr_t addr;
 
-	plat->max_hz = dev_read_u32_default(bus, "spi-max-frequency", 500000);
+	plat->max_hz = dev_read_u32_default(bus, "spi-max-frequency", U32_MAX);
 	plat->bus_num = dev_read_u32_default(bus, "bus-num", 0);
 	addr = dev_read_addr(bus);
 


### PR DESCRIPTION
The driver reads spi-max-frequency from the controller DT node as a cap applied in set_speed(). Upstream Linux DTS places spi-max-frequency only on child device nodes (the flash), not on the controller node, so the driver fell back to the 500 kHz default — throttling every transfer to 1/20th of the intended speed.

The Linux adi SPI driver (spi-adi.c) never reads spi-max-frequency from the controller node at all; speed comes entirely from the per-transfer speed_hz. Default to U32_MAX so that when the controller node has no cap, the per-device spi-max-frequency governs without interference.