### PR TITLE
mtd: spi-nor: call schedule() in read loop to service watchdog

### DIFF
--- a/drivers/mtd/spi/spi-nor-core.c
+++ b/drivers/mtd/spi/spi-nor-core.c
@@ -1605,6 +1605,7 @@ static int spi_nor_read(struct mtd_info *mtd, loff_t from, size_t len,
 	}
 
 	while (len) {
+		schedule();
 		read_len = len;
 		offset = from;
 


### PR DESCRIPTION
The erase and write loops already call schedule() to prevent watchdog starvation, but spi_nor_read() had no equivalent. During 'sf update', if the target region matches the source (no erase/write needed), only reads occur and the watchdog is never serviced, causing a reset on large flash operations.