### PR TITLE
.github/llm: add llm reviews

### DIFF
--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -1,0 +1,243 @@
+name: LLM Agent
+run-name: LLM run ${{ inputs.ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag, PR number, or SHA to checkout"
+        required: false
+        type: string
+      prompt:
+        description: "Prompt to use, overwrites the default"
+        required: false
+        type: string
+        default: ""
+      prompt-extra:
+        description: "Extra prompt to concatenate"
+        required: false
+        type: string
+        default: ""
+      model:
+        description: "Model size"
+        type: choice
+        options:
+        - small
+        - medium
+        - large
+      strategy:
+        description: "Review strategy"
+        type: choice
+        options:
+        - commit
+        - files
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ${{ github.ref }}
+      prompt:
+        required: false
+        type: string
+        default: ""
+      prompt-extra:
+        required: false
+        type: string
+        default: ""
+      model:
+        required: false
+        type: string
+        default: "medium"
+      strategy:
+        description: "Review strategy"
+        type: string
+        default: "commit"
+    secrets:
+      PORTKEY_API_KEY:
+        required: true
+
+jobs:
+  llm:
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
+
+    outputs:
+      pr: ${{ steps.llm.outputs.pr }}
+      comment: ${{ steps.llm.outputs.comment }}
+
+    steps:
+      - name: Prepare prompt
+        run: |
+          prompt_file=$(mktemp --suffix=.md)
+          echo "prompt_file=$prompt_file" >> "$GITHUB_ENV"
+
+          cat <<'EOF' > "$prompt_file"
+          ${{ inputs.prompt }}
+          EOF
+
+          grep -q '[^[:space:]]' "$prompt_file" || \
+          cat <<'EOF' > "$prompt_file"
+          # Run a deep U-Boot analysis.
+
+          Your review should be based on the current u-boot documentation at
+          ./doc/ . Never says things you are unsure about.
+          The U-Boot and Linux kernel are related but independent. This means
+          that skills for Linux also apply to U-Boot.
+
+          You have access to multi-architecture compilers and `$CI_WORKTREE/ci/build.sh` (already sourced)
+          contain multiple bash methods that run during the CI/CD that you can use to
+          replicate the CI/CD steps, for example, to compile for 'arm' a minimal
+          defconfig, do
+          ```
+          $ make mrproper
+          $ set_arch gcc_arm
+             CXX=gcc-13
+             ARCH=arm
+             CROSS_COMPILE=arm-linux-
+          $ make <defconfig>
+          $ make
+          ```
+          You can always do `type set_arch` to get the bash method body or the command source.
+          You must use the set_arch command, it properly sets the correct compilers for all
+          architectures, for example, `set_arch gcc_aarch64` sets `CROSS_COMPILE=aarch64-linux-`.
+          The available compilers are $set_arch_available
+
+          You shall install pip packages to help you review, test and debug;
+          a venv is already active.
+          The virtual environment includes $venv_packages.
+          You shall upgrade/downgrade these packages if needed.
+
+          Do **not** review commits starting with "[TMP]", "[ADI]", "[CI]",
+          they are not part of the series but to change the CI/CD or temporally change behaviour.
+          You **must** check the appropriate datasheets for devices drivers, always convert pdfs
+          before reading it, in particular, camelot-py is already installed.
+
+          Pre-converted (with docling), may be available at the git tree:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling
+
+          for example:
+            https://www.analog.com/media/en/technical-documentation/data-sheets/max17335.pdf
+          can be fetched with:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/media/en/technical-documentation/data-sheets/max17335.md
+
+          If not available,
+          `python3 $CI_WORKTREE/ci/extract_register_map.py ./datasheet.pdf`
+          extract register maps from datasheets and should work on most cases.
+
+          A sitemap with all pdfs, including the datasheets, is available at:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/en-pdf-sitemap.xml
+            (mirror of https://www.analog.com/media/en/en-pdf-sitemap.xml)
+
+          EOF
+
+          if [[ "${{ inputs.strategy }}" == "files" ]]; then
+            cat <<'EOF' >> "$prompt_file"
+          ## File Review Protocol
+
+          Context: Certain files have been modified intentionally to act as markers for review.
+          **Requirement:** When a file is modified in this set, you must review the full-file.
+          Logic:
+          1. Identify files containing the `/* touch */` comment or minor placeholder changes.
+          2. Disregard the placeholder change itself.
+          3. Analyze the entire content of that file.
+          EOF
+          fi
+
+          cat <<'EOF' >> "$prompt_file"
+          ${{ inputs.prompt-extra }}
+          EOF
+
+      - name: Get sources
+        run: |
+          ref="refs/heads/ci"
+          org_repo="analogdevicesinc/u-boot"
+          ci_worktree="$(mktemp -d)"
+
+          get_file () {
+            echo https://raw.githubusercontent.com/$org_repo/$ref/$1
+            curl -sL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -o "$ci_worktree/$1" \
+                https://raw.githubusercontent.com/$org_repo/$ref/$1
+          }
+
+          mkdir "$ci_worktree/ci"
+          get_file "ci/build.sh"
+
+          echo "CI_WORKTREE=$ci_worktree" >> "$GITHUB_ENV"
+          echo "sh_source=$ci_worktree/ci/build.sh" >> "$GITHUB_ENV"
+
+      - name: Setup skills
+        run: |
+          prompt_dir="$(mktemp -d)"
+          echo "prompt_dir=$prompt_dir" >> "$GITHUB_ENV"
+          git clone --depth 1 https://github.com/masoncl/review-prompts "$prompt_dir" && cd $_
+
+          PI=~/.pi/agent
+          PROMPTS_DIR=$PI/_prompts
+
+          pushd "$prompt_dir"
+          mkdir -p $PI/_prompts/kernel
+          cp kernel/*.md $PI/_prompts/kernel
+          cp -r kernel/subsystem $PI/_prompts/kernel
+
+          mkdir -p $PI/prompts
+          pushd kernel/slash-commands
+          for f in *.md; do
+             sed  -e "s|{{KERNEL_REVIEW_PROMPTS_DIR}}|$PI/_prompts/kernel|g" \
+                  -e "s|{{REVIEW_DIR}}|$PI/_prompts/kernel|g" "$f" \
+                  > "$PI/prompts/$f"
+          done
+          popd
+
+          mkdir -p $PI/skills/kernel
+          sed "s|{{KERNEL_REVIEW_PROMPTS_DIR}}|$PI/_prompts/kernel|g" "kernel/skills/kernel.md" > "$PI/skills/kernel/kernel.md"
+          popd
+
+      - name: Prepare tools
+        shell: bash
+        run: |
+          py_venv="$(mktemp -d)"
+          echo "py_venv=$py_venv" >> "$GITHUB_ENV"
+
+          python3 -m venv $py_venv
+          source $py_venv/bin/activate
+          python3 -m ensurepip --upgrade
+          pip install adi-doctools camelot-py
+
+      - name: Extra magic vars
+        run: |
+          source "${{ env.sh_source }}"
+          echo "set_arch_available=$(set_arch | tail -1)" >> $GITHUB_ENV
+
+      - uses: analogdevicesinc/doctools/llm@action
+        id: llm
+        with:
+          ref: ${{ inputs.ref }}
+          model: ${{ inputs.model }}
+          prompt-file: ${{ env.prompt_file }}
+          api-key: ${{ secrets.PORTKEY_API_KEY }}
+          py-venv: ${{ env.py_venv }}
+          sh-source: ${{ env.sh_source }}
+
+      - name: Clean-up
+        if: always()
+        run: |
+          rm -f "$prompt_file"
+          rm -rf "$prompt_dir"
+          rm -rf "$py_venv"
+          rm -rf "$CI_WORKTREE"
+
+  pr-comment:
+    runs-on: ubuntu-slim
+    needs: llm
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: analogdevicesinc/doctools/gh-pr-comment@action
+        with:
+          pr: ${{ needs.llm.outputs.pr }}
+          body: ${{ needs.llm.outputs.comment }}


### PR DESCRIPTION
Based on analogdevicesinc/linux/ci/.github/workflows/llm.yml, add a llm.yml dispatch workflow to run code reviews. The llm is instructed to read ./doc/, no specific u-boot skill is configured.