### PR TITLE
arm: dts: Add dts overlays for the sc598

### DIFF
--- a/arch/arm/dts/Makefile
+++ b/arch/arm/dts/Makefile
@@ -1196,7 +1196,7 @@ dtb-$(CONFIG_TARGET_SC589_MINI) += sc589-mini.dtb
 dtb-$(CONFIG_TARGET_SC589_EZKIT) += sc589-ezkit.dtb
 dtb-$(CONFIG_TARGET_SC594_SOM_EZKIT) += sc594-som-ezkit.dtb
 dtb-$(CONFIG_TARGET_SC594_SOM_EZLITE) += sc594-som-ezlite.dtb
-dtb-$(CONFIG_TARGET_SC598_SOM_EZKIT) += sc598-som-ezkit.dtb
+dtb-$(CONFIG_TARGET_SC598_SOM_EZKIT) += sc598-som-ezkit.dtb sc598-som-ezkit-sd.dtb
 dtb-$(CONFIG_TARGET_SC598_SOM_EZLITE) += sc598-som-ezlite.dtb
 
 ifneq ($(CONFIG_TARGET_IMX8MP_RSB3720A1_4G)$(CONFIG_TARGET_IMX8MP_RSB3720A1_6G),)

--- a/arch/arm/dts/sc598-som-ezkit-sd.dts
+++ b/arch/arm/dts/sc598-som-ezkit-sd.dts
@@ -11,7 +11,7 @@
 	som-emmc {
 		gpio-hog;
 		gpios = <8 GPIO_ACTIVE_LOW>;
-		output-high;
+		output-low;
 		line-name = "som-emmc-en";
 		bootph-pre-ram;
 	};
@@ -19,8 +19,14 @@
 	crr-sdcard {
 		gpio-hog;
 		gpios = <9 GPIO_ACTIVE_LOW>;
-		output-low;
+		output-high;
 		line-name = "crr-sdcard-en";
 		bootph-pre-ram;
 	};
+};
+
+&mmc0 {
+	max-frequency = <44000000>;
+	bus-width = <4>;
+	no-1-8-v;
 };

--- a/arch/arm/dts/sc598-som-ezkit.dtsi
+++ b/arch/arm/dts/sc598-som-ezkit.dtsi
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * (C) Copyright 2024 - Analog Devices, Inc.
+ */
+
+/dts-v1/;
+
+#include "sc598-som-revE.dtsi"
+
+/ {
+	model = "ADI SC598-SOM-EZKIT";
+	compatible = "adi,sc598-som-ezkit", "adi,sc59x-64";
+};
+
+&i2c2 {
+	crr_gpio_expander: mcp23017@22 {
+		compatible = "microchip,mcp23017";
+		reg = <0x22>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		bootph-pre-ram;
+
+		eeprom {
+			gpio-hog;
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eeprom-en";
+			bootph-pre-ram;
+		};
+
+		pushbutton {
+			gpio-hog;
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton-en";
+			bootph-pre-ram;
+		};
+
+		microsd {
+			gpio-hog;
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "microsd-spi";
+			bootph-pre-ram;
+		};
+
+		ftdi {
+			gpio-hog;
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "ftdi-usb-en";
+			bootph-pre-ram;
+		};
+
+		can {
+			gpio-hog;
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can-en";
+			bootph-pre-ram;
+		};
+
+		adau1962 {
+			gpio-hog;
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1962-en";
+			bootph-pre-ram;
+		};
+
+		adau1979 {
+			gpio-hog;
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1979-en";
+			bootph-pre-ram;
+		};
+
+		octal {
+			gpio-hog;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "octal-spi-cs-en";
+			bootph-pre-ram;
+		};
+
+		spdif-dig {
+			gpio-hog;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
+			bootph-pre-ram;
+		};
+
+		spdif-opt {
+			gpio-hog;
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-optical-en";
+			bootph-pre-ram;
+		};
+
+		audio-jack {
+			gpio-hog;
+			gpios = <11 GPIO_ACTIVE_HIGH>;
+			output-high;
+			line-name = "audio-jack-sel";
+			bootph-pre-ram;
+		};
+
+		mlb {
+			gpio-hog;
+			gpios = <12 GPIO_ACTIVE_HIGH>;
+			output-high;
+			line-name = "~mlb-en";
+			bootph-pre-ram;
+		};
+
+		eth1 {
+			gpio-hog;
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth1-en";
+			bootph-pre-ram;
+		};
+
+		eth1-reset {
+			gpio-hog;
+			gpios = <14 GPIO_ACTIVE_LOW>;
+			/*
+			 * USB0 lines are shared with Eth1 so  Eth PHY must be held in reset
+			 * when using the USB
+			 */
+			output-high;
+			line-name = "eth1-reset";
+			bootph-pre-ram;
+		};
+
+		gige-reset {
+			gpio-hog;
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "gige-reset";
+			bootph-pre-ram;
+		};
+	};
+};
+
+&ospi {
+	status = "okay";
+
+	clocks = <&clk ADSP_SC598_CLK_OSPI_REFCLK>;
+
+	flash0: mx66lm1g45@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor", "mx66lm1g45";
+		reg = <0>;
+
+		/*
+		 * This is board dependent to some extent.  We've been able to
+		 *set it higher on some boards
+		 */
+		spi-max-frequency = <66666666>;
+		cdns,spi-calib-frequency = <10000000>;
+
+		spi-tx-bus-width = <8>;
+		spi-rx-bus-width = <8>;
+
+		tshsl-ns = <50>;
+		tsd2d-ns = <50>;
+		tchsh-ns = <4>;
+		tslch-ns = <4>;
+		bootph-pre-ram;
+
+		cdns,dqs;
+		cdns,phy;
+	};
+};

--- a/arch/arm/dts/sc598-som-ezlite.dts
+++ b/arch/arm/dts/sc598-som-ezlite.dts
@@ -12,6 +12,24 @@
 	compatible = "adi,sc598-som-ezlite", "adi,sc59x-64";
 };
 
+&som_gpio_expander {
+	som-emmc {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "som-emmc-en";
+		bootph-pre-ram;
+	};
+
+	crr-sdcard {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "crr-sdcard-en";
+		bootph-pre-ram;
+	};
+};
+
 &i2c2 {
 	crr_gpio_expander: adp5588@30 {
 		compatible = "adi,adp5588";

--- a/arch/arm/dts/sc598-som-revD.dtsi
+++ b/arch/arm/dts/sc598-som-revD.dtsi
@@ -73,22 +73,6 @@
 			line-name = "uart0-flow-en";
 			bootph-pre-ram;
 		};
-
-		som-emmc {
-			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "som-emmc-en";
-			bootph-pre-ram;
-		};
-
-		crr-sdcard {
-			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_LOW>;
-			output-low;
-			line-name = "crr-sdcard-en";
-			bootph-pre-ram;
-		};
 	};
 };
 

--- a/arch/arm/dts/sc598-som-revE.dtsi
+++ b/arch/arm/dts/sc598-som-revE.dtsi
@@ -47,20 +47,6 @@
 			line-name = "som-flash-cs-en";
 		};
 
-		som-emmc {
-			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "som-emmc-en";
-		};
-
-		crr-sdcard {
-			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_LOW>;
-			output-low;
-			line-name = "crr-sdcard-en";
-		};
-
 		led-ds3 {
 			gpio-hog;
 			gpios = <15 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
The eMMC and SD card on the sc598 share pins, so they cannot be used at the same time. Previously, this was managed with a patch applied by the relevant build system, but patches are brittle and have to be maintained. Instead, they have been replaced by dt overlays which will create two separate device trees, one for eMMC and one for SD card, which can then be selected by the build system.