### PR TITLE
Revert "[ADI] .github: add job to upload to Cloudsmith"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,18 +40,3 @@ jobs:
 
   check:
     uses: analogdevicesinc/u-boot/.github/workflows/checks.yml@ci
-
-  deploy_cloudsmith_checks:
-    needs: [build_arm, build_aarch64, check]
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
-    uses: analogdevicesinc/linux/.github/workflows/upload-to-cloudsmith.yml@ci
-    secrets:
-      CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
-      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-    permissions:
-      id-token: write
-      contents: read
-      actions: read
-    with:
-      artifacts: >
-        u-boot-*


### PR DESCRIPTION
Wrong location, should be inside the build share action. We don't want to duplicate this for every branch.
This reverts commit ea293687d1b1d65d5292de476036916c2895d514.