### PR TITLE
[ADI] checks: Fix Check defconfigs step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,10 +77,12 @@ jobs:
     - name: Check defconfigs
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
+        command -v yq || exit 0
         # Collect all defconfigs mentioned in the top-level and look for changes
-        configs=($(awk '/ARCH:/{arch=$2} /DEFCONFIG:/{print arch "/" $2}' \
-                   .github/workflows/top-level.yml | \
-                 sed 's/"//g'))
+        configs="$(yq -r '.jobs[]
+                    | select(.uses == "analogdevicesinc/u-boot/.github/workflows/build.yml@*")
+                    | "\(.with.arch)/\(.with.defconfig)"
+                  ' .github/workflows/top-level.yml)"
         source ./ci/build.sh
         check_assert_defconfigs ${configs[@]}
 


### PR DESCRIPTION
Replace the broken awk-based extraction with yq, matching the approach already used in the Linux checks workflow. The previous awk pattern matched uppercase ARCH:/DEFCONFIG: tokens which were never present in top-level.yml, so check_assert_defconfigs was always called with no arguments.

Use arch/defconfig as the output format to match the slash-delimited argument format expected by check_assert_defconfigs, fixing a separator bug present in the Linux version which uses a space.