### PR TITLE
revert the removal of the matrix

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -12,65 +12,31 @@ permissions:
   contents: read
 
 jobs:
-  build_arm_sc573-ezlite_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
+  build_arm:
+    uses: analogdevicesinc/u-boot/.github/workflows/build-arm.yml@ci
     with:
-      arch: arm
-      defconfig: sc573-ezlite_defconfig
+      defconfig: ${{ matrix.defconfig }}
+    strategy:
+      matrix:
+        defconfig:
+          - 'sc573-ezlite_defconfig'
+          - 'sc584-ezkit_defconfig'
+          - 'sc589-ezkit_defconfig'
+          - 'sc589-mini_defconfig'
+          - 'sc594-som-ezkit-spl_defconfig'
+          - 'sc594-som-ezlite-spl_defconfig'
 
-  build_arm_sc584-ezkit_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
+  build_aarch64:
+    uses: analogdevicesinc/u-boot/.github/workflows/build-aarch64.yml@ci
     with:
-      arch: arm
-      defconfig: sc584-ezkit_defconfig
-
-  build_arm_sc589-ezkit_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm
-      defconfig: sc589-ezkit_defconfig
-
-  build_arm_sc589-mini_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm
-      defconfig: sc589-mini_defconfig
-
-  build_arm_sc594-som-ezkit-spl_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm
-      defconfig: sc594-som-ezkit-spl_defconfig
-
-  build_arm_sc594-som-ezlite-spl_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm
-      defconfig: sc594-som-ezlite-spl_defconfig
-
-  build_aarch64_sc598-htol-spl_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm64
-      defconfig: sc598-htol-spl_defconfig
-
-  build_aarch64_sc598-som-ezkit-spl_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm64
-      defconfig: sc598-som-ezkit-spl_defconfig
-
-  build_aarch64_sc598-som-ezlite-spl_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm64
-      defconfig: sc598-som-ezlite-spl_defconfig
-
-  build_aarch64_xilinx_zynqmp_virt_defconfig:
-    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
-    with:
-      arch: arm64
-      defconfig: xilinx_zynqmp_virt_defconfig
+      defconfig: ${{ matrix.defconfig }}
+    strategy:
+      matrix:
+        defconfig:
+          - 'sc598-htol-spl_defconfig'
+          - 'sc598-som-ezkit-spl_defconfig'
+          - 'sc598-som-ezlite-spl_defconfig'
+          - 'xilinx_zynqmp_virt_defconfig'
 
   checks:
     uses: analogdevicesinc/u-boot/.github/workflows/checks.yml@ci

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -13,8 +13,9 @@ permissions:
 
 jobs:
   build_arm:
-    uses: analogdevicesinc/u-boot/.github/workflows/build-arm.yml@ci
+    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
     with:
+      arch: arm
       defconfig: ${{ matrix.defconfig }}
     strategy:
       matrix:
@@ -27,8 +28,9 @@ jobs:
           - 'sc594-som-ezlite-spl_defconfig'
 
   build_aarch64:
-    uses: analogdevicesinc/u-boot/.github/workflows/build-aarch64.yml@ci
+    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
     with:
+      arch: arm64
       defconfig: ${{ matrix.defconfig }}
     strategy:
       matrix:
@@ -40,3 +42,18 @@ jobs:
 
   checks:
     uses: analogdevicesinc/u-boot/.github/workflows/checks.yml@ci
+
+  deploy_cloudsmith:
+    needs: [build_arm, build_aarch64, checks]
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
+    uses: analogdevicesinc/linux/.github/workflows/upload-to-cloudsmith.yml@ci
+    secrets:
+      CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    with:
+      artifacts: >
+        *


### PR DESCRIPTION
The matrix is a solid improvement to allow concise 'needs' in the next steps:

```

  deploy_cloudsmith:
    needs: [build_arm, build_aarch64, check]
    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
    uses: analogdevicesinc/linux/.github/workflows/upload-to-cloudsmith.yml@ci
    secrets:
      CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
    permissions:
      id-token: write
      contents: read
      actions: read
    with:
      artifacts: >
        u-boot-*
```