### PR TITLE
improve yq matching patterns

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -12,9 +12,8 @@ jobs:
     uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
     secrets: inherit
     permissions:
-      actions: read
       contents: read
-      id-token: write
     with:
       arch: arm64
       defconfig: ${{ inputs.defconfig }}
+

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -12,9 +12,8 @@ jobs:
     uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
     secrets: inherit
     permissions:
-      actions: read
       contents: read
-      id-token: write
     with:
       arch: arm
       defconfig: ${{ inputs.defconfig }}
+

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,10 +77,13 @@ jobs:
     - name: Check defconfigs
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
+        command -v yq || exit 0
         # Collect all defconfigs mentioned in the top-level and look for changes
-        configs=($(awk '/ARCH:/{arch=$2} /DEFCONFIG:/{print arch "/" $2}' \
-                   .github/workflows/top-level.yml | \
-                 sed 's/"//g'))
+        configs="$(yq -r '.jobs[]
+                    | select(.uses == "analogdevicesinc/u-boot/.github/workflows/build.yml@*")
+                    | (.with.defconfig, (.strategy.matrix.defconfig[]?))
+                    | select(. != null and . != "$" + "{{ matrix.defconfig }}")
+                  ' .github/workflows/top-level.yml)"
         source ./ci/build.sh
         check_assert_defconfigs ${configs[@]}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,12 +77,10 @@ jobs:
     - name: Check defconfigs
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        command -v yq || exit 0
         # Collect all defconfigs mentioned in the top-level and look for changes
-        configs="$(yq -r '.jobs[]
-                    | select(.uses == "analogdevicesinc/u-boot/.github/workflows/build.yml@*")
-                    | "\(.with.arch)/\(.with.defconfig)"
-                  ' .github/workflows/top-level.yml)"
+        configs=($(awk '/ARCH:/{arch=$2} /DEFCONFIG:/{print arch "/" $2}' \
+                   .github/workflows/top-level.yml | \
+                 sed 's/"//g'))
         source ./ci/build.sh
         check_assert_defconfigs ${configs[@]}
 


### PR DESCRIPTION

Syncronize matcher for defconfigs with the linux repository, that is,
at the collect all defconfigs mentioned in the top-level, support
both formats:

  build_arm:
    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
    strategy:
      matrix:
        defconfig:
          - 'adi_a_defconfig'
          - 'adi_b_defconfig'
          - 'adi_c_defconfig'

  build_gcc_x86_64:
    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
    with:
      defconfig: "adi_ci_defconfig"

also reverts unneeded changes.

test with
```
echo "
jobs:
  build_gcc_x86_64:
    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
    needs: [checks]
    if: needs.checks.outputs.fatal != 'true'
    secrets: inherit
    permissions:
      contents: read
    with:
      compiler: gcc
      arch: x86
      defconfig: adi_ci_defconfig

  build_arm:
    uses: analogdevicesinc/u-boot/.github/workflows/build.yml@ci
    with:
      arch: arm
      defconfig: \${{ matrix.defconfig }}
    strategy:
      matrix:
        defconfig:
          - 'sc573-ezlite_defconfig'
          - 'sc584-ezkit_defconfig'
          - 'sc589-ezkit_defconfig'
          - 'sc589-mini_defconfig'
          - 'sc594-som-ezkit-spl_defconfig'
          - 'sc594-som-ezlite-spl_defconfig'
" > /tmp/t.yml
yq -r '.jobs[]
        | select(.uses == "analogdevicesinc/u-boot/.github/workflows/build.yml@*")
        | (.with.defconfig, (.strategy.matrix.defconfig[]?))
        | select(. != null and . != "$" + "{{ matrix.defconfig }}")
		'  /tmp/t.yml ; echo $?
```

related: #125