### PR TITLE
ci/build: add check_qconfig_sync, replace check_assert_defconfigs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,16 @@ jobs:
         mkdir -p ci
         get_file ci/build.sh
         get_file ci/runner_env.sh
+        get_file ci/buildman
+        cp ci/buildman ~/.buildman
+
+    - name: Install dependencies
+      if: ${{ runner.environment == 'github-hosted' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          gcc-arm-none-eabi \
+          gcc-aarch64-linux-gnu
 
     - name: Apply cocci
       run: |
@@ -74,18 +84,17 @@ jobs:
         [ $status -eq 124 ] && echo "step_fail_coccicheck_timeout=true" >> "$GITHUB_ENV"
         exit $status
 
-    - name: Check defconfigs
+    - name: Check qconfig
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        command -v yq || exit 0
-        # Collect all defconfigs mentioned in the top-level and look for changes
+        command -v yq
         configs="$(yq -r '.jobs[]
                     | select(.uses == "analogdevicesinc/u-boot/.github/workflows/build.yml@*")
                     | (.with.defconfig, (.strategy.matrix.defconfig[]?))
                     | select(. != null and . != "$" + "{{ matrix.defconfig }}")
                   ' .github/workflows/top-level.yml)"
         source ./ci/build.sh
-        check_assert_defconfigs ${configs[@]}
+        check_qconfig_sync ${configs[@]}
 
     - name: Export labels
       if: ${{ !cancelled() }}

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -275,40 +275,64 @@ check_license() {
 	return $fail
 }
 
-check_assert_defconfigs() {
-	export step_name="check_assert_defconfigs"
+check_qconfig_sync() {
+	export step_name="check_qconfig_sync"
 	local fail=0
-	local arch
-	local defconfig
-	local file
-	local message="
-	Verify if the changes are coherent, for example, the changes were not
-	caused by a mistakenly set Kconfig, and if so, run 'make savedefconfig',
-	overwrite the defconfig and commit it.
-	"
+	local list=$(mktemp)
+	local out
+	local changed=0
 
 	echo "$step_name"
-	for arg in "$@"; do
-		arch=$(cut -d "/" -f1 <<< "$arg")
-		[[ "$arch" == "arm64" ]] && arch_=aarch64 || arch_=$arch
-		defconfig=$(cut -d "/" -f2 <<< "$arg")
-		file=arch/$arch/configs/$defconfig
 
-		if [[ -f $file ]]; then
-			echo $file
-			set_arch gcc_$arch_ 1>/dev/null
-			make $defconfig savedefconfig 1>/dev/null
-			rm .config
+	printf '%s\n' "$@" > "$list"
+	git diff --diff-filter=A --name-only "$base_sha..$head_sha" \
+		-- 'arch/*/configs/*_defconfig' | xargs -r -n1 basename >> "$list"
 
-			mv defconfig $file
-			out=$(git diff $_color --exit-code $file) || {
-				_fmt "::error file=$file::$step_name: Defconfig '$file' changed. $message
-				      $out"
-				fail=1
-			}
-			git restore $file
-		fi
-	done
+	if [[ ! -s "$list" ]]; then
+		rm -f "$list"
+		return 0
+	fi
+
+	local arm_gcc aarch64_gcc
+	arm_gcc=$(command -v arm-none-eabi-gcc 2>/dev/null || true)
+	aarch64_gcc=$(command -v aarch64-linux-gnu-gcc 2>/dev/null || true)
+	if [[ -n "$arm_gcc" || -n "$aarch64_gcc" ]]; then
+		cat > ~/.buildman <<-EOF
+		[toolchain-prefix]
+		arm = ${arm_gcc%gcc}
+		aarch64 = ${aarch64_gcc%gcc}
+		EOF
+	fi
+
+	python3 tools/qconfig.py -s -d "$list"
+
+	out=$(git diff $_color HEAD --name-only)
+	if [[ -n "$out" ]]; then
+		git diff $_color HEAD
+		while read -r file; do
+			[[ -z "$file" ]] && continue
+			_fmt "::error file=$(_file "$file")::$step_name: qconfig.py modified this file."
+			changed=1
+		done <<< "$out"
+		fail=1
+	fi
+
+	out=$(git ls-files --others --exclude-standard -- ':!ci/' ':!qconfig.db' ':!qconfig.failed')
+	if [[ -n "$out" ]]; then
+		while read -r file; do
+			[[ -z "$file" ]] && continue
+			echo "$file"
+			_fmt "::error file=$(_file "$file")::$step_name: qconfig.py created this untracked file."
+			changed=1
+		done <<< "$out"
+		[[ "$changed" == "1" ]] && fail=1
+	fi
+
+	[[ "$changed" == "0" ]] && echo "qconfig.py produced no tree changes"
+
+	git restore .
+	git clean -fd -e ci/
+	rm -f "$list"
 
 	return $fail
 }

--- a/ci/buildman
+++ b/ci/buildman
@@ -1,0 +1,3 @@
+[toolchain]
+arm = /usr/bin
+aarch64 = /usr/bin


### PR DESCRIPTION
Follow-up to #70, which was never merged and is not trivial to rebase given other changes.

---

Use qconfig.py -s to verify that defconfigs are canonically ordered and contain no redundant symbols (options already implied by the Kconfig graph). The check runs on all defconfigs listed in the top-level workflow and on any defconfig files newly added in the PR range, so new boards are validated without needing to be wired up to the top-level workflow first.

Replace check_assert_defconfigs, which ran make savedefconfig per-board in a serial loop, with check_qconfig_sync that delegates the full Kconfig expansion to qconfig.py in a single invocation. Detect changes via git diff HEAD after the run and report each modified file as a GitHub annotation. Also detect any unexpected untracked files left behind, excluding the known qconfig.db and qconfig.failed side-effects.

Wire it up in .github/workflows/checks.yml: rename the 'Check defconfigs' step to 'Check qconfig', add a 'Configure buildman toolchains' step before it to write ~/.buildman with the runner's toolchain prefixes, and add a defconfigs workflow input so callers can supplement the defconfig list extracted from top-level.yml.