### PR TITLE
ci: package native U-Boot elf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,14 +81,14 @@ jobs:
           echo "DIST=$dist" >> $GITHUB_ENV
 
           cp "$KBUILD_OUTPUT/u-boot" "$dist"
-          cp "$KBUILD_OUTPUT/u-boot.elf" "$dist"
+          [[ -f "$KBUILD_OUTPUT/u-boot.elf" ]] && cp "$KBUILD_OUTPUT/u-boot.elf" "$dist"
           cp "$KBUILD_OUTPUT/u-boot.bin" "$dist"
           [[ -f "$KBUILD_OUTPUT/u-boot.ldr" ]] && cp "$KBUILD_OUTPUT/u-boot.ldr" "$dist"
           cp "$KBUILD_OUTPUT/spl/u-boot-spl" "$dist"
           cp "$KBUILD_OUTPUT/spl/u-boot-spl.bin" "$dist"
           [[ -f "$KBUILD_OUTPUT/spl/u-boot-spl.ldr" ]] && cp "$KBUILD_OUTPUT/spl/u-boot-spl.ldr" "$dist"
 
-          echo "uboot=u-boot.elf" > "$dist/context.txt"
+          echo "uboot=u-boot" > "$dist/context.txt"
           echo "uboot_release=$uversion" >> "$dist/context.txt"
           echo "uboot_defconfig=${{ inputs.defconfig }}" >> "$dist/context.txt"
           echo "compiler_name=${{ env.compiler_name }}" >> "$dist/context.txt"


### PR DESCRIPTION
I noticed that ci fails recently,

https://github.com/analogdevicesinc/u-boot/actions/runs/29811332530/job/88572743195?pr=130#step:8:42

It was defaulting to u-boot.elf, but u-boot is U-Boot’s standard, real linked ELF output. u-boot.elf is an additional, optional ELF rebuilt from u-boot.bin when CONFIG_REMAKE_ELF=y.

---

The reusable build workflow declared u-boot.elf as the primary artifact and copied it unconditionally. Some valid board configurations do not generate this optional reconstructed ELF, causing artifact preparation to fail.

Use the normal u-boot build output as the primary artifact and copy u-boot.elf only when it is available.