### PR TITLE
ci/build: fail the job on hard check errors

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -165,6 +165,7 @@ check_checkpatch() {
 	[[ "$strategy" == "file" ]] && (git switch - 1>/dev/null; git branch -D $tmp_branch_name)
 
 	_set_step_warn $warn
+	[[ "$fail" == "1" ]] && set_step_fail "$step_name"
 	return $fail
 }
 
@@ -272,6 +273,7 @@ check_license() {
 	done
 
 	_set_step_warn $warn
+	[[ "$fail" == "1" ]] && set_step_fail "$step_name"
 	return $fail
 }
 
@@ -334,6 +336,7 @@ check_qconfig_sync() {
 	git clean -fd -e ci/
 	rm -f "$list"
 
+	[[ "$fail" == "1" ]] && set_step_fail "$step_name"
 	return $fail
 }
 


### PR DESCRIPTION
A bare `return 1` does not trigger the trap, so the error was annotated and the step exited non-zero, yet the job (continue-on-error: true) and the aggregated result stayed ok. 

A commit missing a Signed-off-by line, for example, passed CI. https://github.com/analogdevicesinc/u-boot/actions/runs/30635738326/job/91172768680?pr=136#step:8:39

Not tested whether this triggers or not, not on the corp net rn. @gastmaier 