### PR TITLE
.github: add hardware tests

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -45,6 +45,26 @@ jobs:
   checks:
     uses: analogdevicesinc/u-boot/.github/workflows/checks.yml@ci
 
+  hardware-test:
+    needs: [build_aarch64]
+    if: ${{ github.event_name != 'release' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - needs: '["sc598", "ezkit"]'
+          - needs: '["sc598", "ezlite"]'
+          - needs: '["sc846", "ezkit"]'
+    uses: analogdevicesinc/u-boot/.github/workflows/hw-test.yml@ci
+    with:
+      test-set: 'adsp/u-boot'
+      needs: ${{ matrix.needs }}
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
   deploy_cloudsmith:
     needs: [build_arm, build_aarch64, checks]
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}


### PR DESCRIPTION
Add a hw-test workflow and wire it into the top-level pipeline so the built images are tested on real hardware via the analogdevicesinc/hw-test.