### PR TITLE
sc846: add support for ELF rproc 

### DIFF
--- a/arch/arm/dts/sc846-som.dts
+++ b/arch/arm/dts/sc846-som.dts
@@ -21,6 +21,10 @@
 	status = "okay";
 };
 
+&sharcfx {
+	status = "okay";
+};
+
 &uart0 {
 	clocks = <&clk ADSP_SC846_CLK_CGU0_SCLK0>;
 };

--- a/arch/arm/dts/sc846.dtsi
+++ b/arch/arm/dts/sc846.dtsi
@@ -16,10 +16,18 @@
 
 	soc {
 		rcu: rcu@0x3108C000 {
-			compatible = "adi,reset-controller";
+			compatible = "syscon", "adi,reset-controller";
 			reg = <0x3108C000 0x1000>;
 			adi,sharc-min = <1>;
-			adi,sharc-max = <2>;
+			adi,sharc-max = <1>;
+			status = "disabled";
+		};
+
+		sharcfx: sharc@0x20400000 {
+			compatible = "adi,sc5xx-rproc";
+			reg = <0x20400000 0x100>;
+			coreid = <1>;
+			adi,rcu = <&rcu>;
 			status = "disabled";
 		};
 

--- a/arch/arm/mach-sc5xx/sc846-som.c
+++ b/arch/arm/mach-sc5xx/sc846-som.c
@@ -22,6 +22,13 @@
 
 #define REG_CSTSGENWR0_CNTCR 0x3110E000  /* or 0x31149000 */
 
+#define SPU0_SECUREP(n)		(REG_SPU0_SECUREP_START + 4 * (n))
+#define SPU_SECUREP_MSEC	(1 << 1)
+
+#define SPU_SECUREP_MSMDMA	128
+#define SPU_SECUREP_MDMA0_SRC	140
+#define SPU_SECUREP_MDMA0_DST	141
+
 static struct mm_region sc846_mem_map[] = {
 	{
 		/* Peripherals */
@@ -91,6 +98,11 @@ void sc5xx_soc_init(void)
 	/* configure smpus permissively */
 	for (i = 0; i < ARRAY_SIZE(smpus); ++i)
 		writel(0x500, smpus[i]);
+
+	writel(SPU_SECUREP_MSEC, SPU0_SECUREP(SPU_SECUREP_MSMDMA));
+	writel(SPU_SECUREP_MSEC, SPU0_SECUREP(SPU_SECUREP_MDMA0_SRC));
+	writel(SPU_SECUREP_MSEC, SPU0_SECUREP(SPU_SECUREP_MDMA0_DST));
+
 
 	asm("mrs x8, scr_el3");
 	asm("orr x8, x8, #(1 << 1)");

--- a/drivers/remoteproc/adi_sc5xx_rproc.c
+++ b/drivers/remoteproc/adi_sc5xx_rproc.c
@@ -62,6 +62,10 @@
 #define RCU0_MSG_C1ACTIVATE		0x00080000		/* Core 1 Activated */
 #define RCU0_MSG_C2ACTIVATE		0x00100000		/* Core 2 Activated */
 
+#define SHARCFX_IRAM_START		0x2F800000
+#define SHARCFX_IRAM_END		0x2F80FFFF
+#define SHARCFX_IRAM_ARM_OFFSET		0x07540000
+
 struct sc5xx_rproc_data {
 	/* Address to load to svect when rebooting core */
 	u32 load_addr;
@@ -118,20 +122,14 @@ static int adi_valid_firmware(struct ldr_hdr *adi_ldr_hdr)
 	return 0;
 }
 
-static int sharc_load(struct udevice *dev, ulong addr, ulong size)
+static int sharc_ldr_load(struct udevice *dev, ulong addr, ulong size)
 {
 	struct sc5xx_rproc_data *priv = dev_get_priv(dev);
 	size_t offset;
 	u8 *buf = (u8 *)addr;
-	struct ldr_hdr *ldr = (struct ldr_hdr *)addr;
 	struct ldr_hdr *block_hdr;
 	struct ldr_hdr *next_hdr;
 
-	if (!adi_valid_firmware(ldr)) {
-		dev_err(dev, "Firmware at 0x%lx does not appear to be an LDR image\n", addr);
-		dev_err(dev, "Note: Signed firmware is not currently supported\n");
-		return -EINVAL;
-	}
 
 	do {
 		block_hdr = (struct ldr_hdr *)buf;
@@ -161,6 +159,36 @@ static int sharc_load(struct udevice *dev, ulong addr, ulong size)
 	} while (1);
 
 	return 0;
+}
+
+static int sharc_elf_load(struct udevice *dev, ulong addr, ulong size)
+{
+	u32 entry_point = rproc_elf_get_boot_addr(dev, addr);
+	struct sc5xx_rproc_data *priv = dev_get_priv(dev);
+
+	priv->load_addr = entry_point;
+
+	return rproc_elf32_load_image(dev, addr, size);
+}
+
+static int sharc_load(struct udevice *dev, ulong addr, ulong size)
+{
+	struct ldr_hdr *ldr = (struct ldr_hdr *)addr;
+
+	if (adi_valid_firmware(ldr)) {
+		return sharc_ldr_load(dev, addr, size);
+	} else {
+		dev_err(dev, "Firmware at 0x%lx does not appear to be an LDR image\n", addr);
+		dev_err(dev, "Note: Signed firmware is not currently supported\n");
+	}
+
+	if (!rproc_elf32_sanity_check(addr, size)) {
+		dev_err(dev, "Found ELF image\n");
+		return sharc_elf_load(dev, addr, size);
+	} else {
+		dev_err(dev, "Firmware at 0x%lx does not appear to be an ELF image\n", addr);
+	}
+	return -EINVAL;
 }
 
 static void sharc_reset(struct sc5xx_rproc_data *priv)
@@ -222,8 +250,28 @@ static int sharc_start(struct udevice *dev)
 	return 0;
 }
 
+void *sc5xx_sharc_pa_to_virt(struct udevice *dev, ulong da, ulong size)
+{
+	struct sc5xx_rproc_data *priv = dev_get_priv(dev);
+	u32 coreid = priv->coreid;
+
+	if (!strncmp(dev->name, "sharcfx", 7)) {
+		return da;
+	}
+
+	//Instruction RAM
+	//SHARC-FX -> ARM
+	//0x2F800000–0x2F80FFFF -> 0x282C0000–0x282CFFFF 64KB
+	if ((da >= SHARCFX_IRAM_START) && (da <= SHARCFX_IRAM_END)) {
+		return da-SHARCFX_IRAM_ARM_OFFSET;
+	}
+
+	return da;
+}
+
 static const struct dm_rproc_ops sc5xx_ops = {
 	.load = sharc_load,
+	.device_to_virt = sc5xx_sharc_pa_to_virt,
 	.start = sharc_start,
 };
 


### PR DESCRIPTION
Commands used for testing:
```
dhcp;
tftp 0x90000000 /sc846/<firmware name>.dxe
rproc init
rproc load 0 0x90000000 ${filesize}
```
firmware with blinking LED's on carrier board.
Will be uploaded to rpmsg-examples git repo
