### PR TITLE
mach-sc5xx: Use common Kernel SPI flash partition offset

### DIFF
--- a/include/env/adi/adi_boot.env
+++ b/include/env/adi/adi_boot.env
@@ -21,9 +21,7 @@ initrd_high=0xffffffffffffffff
 #else
 initrd_high=0xffffffff
 #endif
-#if defined(CONFIG_SC846)
-adi_image_offset=0x210000
-#elif defined(CONFIG_SC59X) || defined(CONFIG_SC59X_64)
+#if defined(CONFIG_SC59X) || defined(CONFIG_SC59X_64) || defined(CONFIG_SC846)
 adi_image_offset=0x100000
 #else
 adi_image_offset=0xd0000


### PR DESCRIPTION
Use the same offset for the ADSP-SC846 Kernel partition in SPI NOR flash as is used by previous generation reference boards