### PR TITLE
board: adi: sc846: Clock xSPI1 from SCLK0_0

### DIFF
--- a/board/adi/sc846-som-ezkit/Kconfig
+++ b/board/adi/sc846-som-ezkit/Kconfig
@@ -107,8 +107,9 @@ config CGU1_DIV_S0SELEX
 	default 8
 
 # SCLK1 extended divisor
+# SCLK1_1 = CGU1_VCO / (2 * 9) = 1800MHz / 18 = 100MHz
 config CGU1_DIV_S1SELEX
-	default 5
+	default 9
 
 # SHARC-FX
 
@@ -147,9 +148,9 @@ config CDU0_CLKO6
 config CDU0_CLKO7
 	default 1
 
-# xSPI2
+# xSPI1
 # 5 sets the input as SCLK1_1
-# SCLK1_0 = CGU1_VCO / 20 = 180MHz
+# SCLK1_1 = CGU1_VCO / (2 * CGU1_DIV_S1SELEX) = 100MHz
 config CDU0_CLKO8
 	default 5
 

--- a/board/adi/sc846-som/Kconfig
+++ b/board/adi/sc846-som/Kconfig
@@ -107,8 +107,9 @@ config CGU1_DIV_S0SELEX
 	default 8
 
 # SCLK1 extended divisor
+# SCLK1_1 = CGU1_VCO / (2 * 9) = 1800MHz / 18 = 100MHz
 config CGU1_DIV_S1SELEX
-	default 5
+	default 9
 
 # SHARC-FX
 
@@ -147,9 +148,9 @@ config CDU0_CLKO6
 config CDU0_CLKO7
 	default 1
 
-# xSPI2
+# xSPI1
 # 5 sets the input as SCLK1_1
-# SCLK1_0 = CGU1_VCO / 20 = 180MHz
+# SCLK1_1 = CGU1_VCO / (2 * CGU1_DIV_S1SELEX) = 100MHz
 config CDU0_CLKO8
 	default 5
 


### PR DESCRIPTION
The xSPI driver programs no divider of its own, so whatever CDU0_CFG8 selects is the interface clock the flash actually sees. CDU0_CLKO8 was set to 5, i.e. SCLK1_1:

  SCLK1_1 = CGU1_VCO / (2 * CGU1_DIV_S1SELEX)
          = (25MHz * 72) / (2 * 5) = 180MHz

That is more than the xSPI flashes on the supported carrier boards can be driven at, and which flash is attached depends on the carrier board. Select SCLK0_0 (125MHz) instead, which is the clock xSPI0 (CDU0_CLKO10) already runs at, so both xSPI controllers share one known-good rate.

While at it, fix the stale comment on CDU0_CLKO8: it referred to xSPI2, named the wrong clock and used a divisor that does not match the formula.

---

This is just a draft and with the goal of making it easy if someone wants to use XSP1 on the carrier. Given that it is still a question mark which memory chip will be used on XSP1 I would keep this as a draft for now