### PR TITLE
board: adi: sc846: fix A55 input clock and drop clk_ignore_unused CCF flag

### DIFF
--- a/board/adi/sc846-som-ezkit/Kconfig
+++ b/board/adi/sc846-som-ezkit/Kconfig
@@ -117,7 +117,7 @@ config CDU0_CLKO0
 
 # CORE 0
 config CDU0_CLKO1
-	default 7
+	default 3
 
 # CORE 1
 config CDU0_CLKO2

--- a/board/adi/sc846-som-ezkit/sc846-som-ezkit.env
+++ b/board/adi/sc846-som-ezkit/sc846-som-ezkit.env
@@ -4,7 +4,7 @@
  * (C) Copyright 2026 - Analog Devices, Inc.
  */
 
-board_bootargs=cma=64M coherent_pool=32M clk_ignore_unused
+board_bootargs=cma=64M coherent_pool=32M
 
 fdt_addr_r=CONFIG_SYS_LOAD_ADDR
 kernel_addr_r=0x9a200000

--- a/board/adi/sc846-som/Kconfig
+++ b/board/adi/sc846-som/Kconfig
@@ -117,7 +117,7 @@ config CDU0_CLKO0
 
 # CORE 0
 config CDU0_CLKO1
-	default 7
+	default 3
 
 # CORE 1
 config CDU0_CLKO2


### PR DESCRIPTION
This PR is the second accompanying fix for https://github.com/analogdevicesinc/linux/pull/3506 to remove the ```clk_ignore_unused``` flag on SC846 SoCs. The changes reparent the ARM processor to use the CCLK0_1 clock and remove ```clk_ignore_unused``` from the kernel boot arguments.

As a result:
- The ARM processor is now clocked at 450 MHz.
- The ARM processor clock rate is now reported correctly in both U-Boot and Linux clock dumps (```clk dump```/```clk_summary```). Previously, the reported rate was 0.

Note: During testing, switching the ARM processor to other input clocks, such as CCLK0_0, causes the processor to hang while booting the kernel. Configurations that clock the ARM core at 1 GHz or 1.2 GHz also result in a kernel boot hang.

Ideally, I want the processor to be clocked at 1.2 GHz. After discussing this with @sipraga and @artursartamonovsadi, this appears to be the preferred configuration. However, the boot failure at these clock rates appears to be a separate issue and will be investigated separately.

For now, using CCLK0_1 at 450 MHz provides a working configuration and allows ```clk_ignore_unused``` to be removed.

Issue for reference: https://github.com/analogdevicesinc/linux/issues/3476